### PR TITLE
closes itp bug.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-libpoly0 (1.3-1) unstable; urgency=medium
+libpoly0 (1.3-2) unstable; urgency=medium
 
-  * Initial release. (Closes: #XXXXXX)
+  * Initial release. (Closes: #864834)
 
  -- Ian A. Mason <iam@csl.sri.com>  Thu, 25 May 2017 13:46:30 +0000


### PR DESCRIPTION
Zero lintain errors.
```
Now running lintian...
Finished running lintian.
```

Plus resulting package has been uploaded to mentors.debian.net
```
dput -f mentors libpoly0_1.3-2_amd64.changes
Checking signature on .changes
gpg: Signature made Thu 15 Jun 2017 04:08:29 PM GMT using RSA key ID F10CFE93
gpg: Good signature from "Ian A. Mason (My Software Signing Key) <iam@csl.sri.com>"
Good signature on /vagrant/ianamason/libpoly0_1.3-2_amd64.changes.
Checking signature on .dsc
gpg: Signature made Thu 15 Jun 2017 03:55:10 PM GMT using RSA key ID F10CFE93
gpg: Good signature from "Ian A. Mason (My Software Signing Key) <iam@csl.sri.com>"
Good signature on /vagrant/ianamason/libpoly0_1.3-2.dsc.
Package includes an .orig.tar.gz file although the debian revision suggests
that it might not be required. Multiple uploads of the .orig.tar.gz may be
rejected by the upload queue management software.
Uploading to mentors (via http to mentors.debian.net):
  Uploading libpoly0_1.3-2.dsc: done.
  Uploading libpoly0_1.3.orig.tar.gz: done.
  Uploading libpoly0_1.3-2.debian.tar.xz: done.
  Uploading libpoly0_1.3-2_amd64.deb: done.
  Uploading libpoly-dev_1.3-2_amd64.deb: done.
  Uploading libpoly-dbg_1.3-2_amd64.deb: done.
  Uploading libpoly0_1.3-2_amd64.changes: done.
Successfully uploaded packages.

```