### PR TITLE
Adding const for (almost) all lp_int_ring_t* arguments.

### DIFF
--- a/include/integer.h
+++ b/include/integer.h
@@ -72,37 +72,37 @@ void lp_integer_construct(lp_integer_t* c);
  * Construct a integer from the given rational x. The rational x must be
  * an integer.
  */
-void lp_integer_construct_from_rational(lp_int_ring_t* K, lp_integer_t* c, const lp_rational_t* q);
+void lp_integer_construct_from_rational(const lp_int_ring_t* K, lp_integer_t* c, const lp_rational_t* q);
 
 /**
  * Construct a integer from the given integer x. The integer will be
  * normalized according to the given ring.
  */
-void lp_integer_construct_from_int(lp_int_ring_t* K, lp_integer_t* c, long x);
+void lp_integer_construct_from_int(const lp_int_ring_t* K, lp_integer_t* c, long x);
 
 /**
  * Construct a integer from the given string representation. The
  * integer will be normalized according to the given ring.
  */
-void lp_integer_construct_from_string(lp_int_ring_t* K, lp_integer_t* c, const char* x, int base);
+void lp_integer_construct_from_string(const lp_int_ring_t* K, lp_integer_t* c, const char* x, int base);
 
 /**
  * Construct a copy of the given integer. The integer will be
  * normalized according to the given ring.
  */
-void lp_integer_construct_copy(lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from);
+void lp_integer_construct_copy(const lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from);
 
 /**
  * Assign the integer a given integer. The integer will be
  * normalized according to the given ring.
  */
-void lp_integer_assign(lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from);
+void lp_integer_assign(const lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from);
 
 /**
  * Assign the integer a given integer. The integer will be
  * normalized according to the given ring.
  */
-void lp_integer_assign_int(lp_int_ring_t* K, lp_integer_t* c, long x);
+void lp_integer_assign_int(const lp_int_ring_t* K, lp_integer_t* c, long x);
 
 /**
  * Deallocates the integer.
@@ -147,30 +147,30 @@ int lp_integer_is_prime(const lp_integer_t* c);
 /**
  * returns true if the integer is zero.
  */
-int lp_integer_is_zero(lp_int_ring_t* K, const lp_integer_t* c);
+int lp_integer_is_zero(const lp_int_ring_t* K, const lp_integer_t* c);
 
 /**
  * Returns true if the integer is in the given ring by value.
  */
-int lp_integer_in_ring(lp_int_ring_t* K, const lp_integer_t* c);
+int lp_integer_in_ring(const lp_int_ring_t* K, const lp_integer_t* c);
 
 /**
  * Returns the sign of the integer. The sign is depends on the ring that
  * the integer was created in (the given ring). In a modular ring, the
  * sign is negative if > floor(M/2) when normalized.
  */
-int lp_integer_sgn(lp_int_ring_t* K, const lp_integer_t* c);
+int lp_integer_sgn(const lp_int_ring_t* K, const lp_integer_t* c);
 
 /**
  * Compare the two integers in the ring. Not necessarily +/- 1, could be
  * any integer, only the sign matters.
  */
-int lp_integer_cmp(lp_int_ring_t* K, const lp_integer_t* c, const lp_integer_t* to);
+int lp_integer_cmp(const lp_int_ring_t* K, const lp_integer_t* c, const lp_integer_t* to);
 
 /**
  * Compare the two integers in the ring. Same as for sgn.
  */
-int lp_integer_cmp_int(lp_int_ring_t* K, const lp_integer_t* c, long to);
+int lp_integer_cmp_int(const lp_int_ring_t* K, const lp_integer_t* c, long to);
 
 /**
  * Returns true if a divides b in the given ring. In Z this is regular
@@ -178,7 +178,7 @@ int lp_integer_cmp_int(lp_int_ring_t* K, const lp_integer_t* c, long to);
  * with modulus M a divides b iff gcd(a, M) divides b. If the ring is prime
  * any non-zero a divides any b (it's a field).
  */
-int lp_integer_divides(lp_int_ring_t* K, const lp_integer_t* a, const lp_integer_t* b);
+int lp_integer_divides(const lp_int_ring_t* K, const lp_integer_t* a, const lp_integer_t* b);
 
 /**
  * Swap two integers.
@@ -188,59 +188,59 @@ void lp_integer_swap(lp_integer_t* a, lp_integer_t* b);
 /**
  * Compute a ++.
  */
-void lp_integer_inc(lp_int_ring_t* K, lp_integer_t* a);
+void lp_integer_inc(const lp_int_ring_t* K, lp_integer_t* a);
 
 /**
  * Compute a --.
  */
-void lp_integer_dec(lp_int_ring_t* K, lp_integer_t* a);
+void lp_integer_dec(const lp_int_ring_t* K, lp_integer_t* a);
 
 /**
  * Compute sum = a + b in the given ring.
  */
-void lp_integer_add(lp_int_ring_t* K, lp_integer_t* sum, const lp_integer_t* a, const lp_integer_t* b);
+void lp_integer_add(const lp_int_ring_t* K, lp_integer_t* sum, const lp_integer_t* a, const lp_integer_t* b);
 
 /**
  * Compute sub = a - b in the given ring.
  */
-void lp_integer_sub(lp_int_ring_t* K, lp_integer_t* sub, const lp_integer_t* a, const lp_integer_t* b);
+void lp_integer_sub(const lp_int_ring_t* K, lp_integer_t* sub, const lp_integer_t* a, const lp_integer_t* b);
 
 /**
  * Compute neg = -a in the given ring. Not that, for example in Z_4, for a =
  * 2, we get that neg = 2. In Z_3 the numbers are in {-1, 0, 1, 2}, and -2 is
  * represented as 2.
  */
-void lp_integer_neg(lp_int_ring_t* K, lp_integer_t* neg, const lp_integer_t* a);
+void lp_integer_neg(const lp_int_ring_t* K, lp_integer_t* neg, const lp_integer_t* a);
 
 /**
  * Compute the absolute value.
  */
-void lp_integer_abs(lp_int_ring_t* K, lp_integer_t* abs, const lp_integer_t* a);
+void lp_integer_abs(const lp_int_ring_t* K, lp_integer_t* abs, const lp_integer_t* a);
 
 /**
  * Compute the inverse of a in the given ring. Assumes it has an inverse.
  */
-void lp_integer_inv(lp_int_ring_t* K, lp_integer_t* inv, const lp_integer_t* a);
+void lp_integer_inv(const lp_int_ring_t* K, lp_integer_t* inv, const lp_integer_t* a);
 
 /**
  * Compute product = a * b in the given ring.
  */
-void lp_integer_mul(lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, const lp_integer_t* b);
+void lp_integer_mul(const lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, const lp_integer_t* b);
 
 /**
  * Compute product = a * b in the given ring.
  */
-void lp_integer_mul_int(lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, long b);
+void lp_integer_mul_int(const lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, long b);
 
 /**
  * Compute product = a*2^n
  */
-void lp_integer_mul_pow2(lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, unsigned n);
+void lp_integer_mul_pow2(const lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, unsigned n);
 
 /**
  * Compute power = a^n in the given ring.
  */
-void lp_integer_pow(lp_int_ring_t* K, lp_integer_t* pow, const lp_integer_t* a, unsigned n);
+void lp_integer_pow(const lp_int_ring_t* K, lp_integer_t* pow, const lp_integer_t* a, unsigned n);
 
 /**
  * Compute the square root of a (in Z).
@@ -250,22 +250,22 @@ void lp_integer_sqrt_Z(lp_integer_t* sqrt, const lp_integer_t* a);
 /**
  * Compute sum_product += a*b in the given ring.
  */
-void lp_integer_add_mul(lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, const lp_integer_t* b);
+void lp_integer_add_mul(const lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, const lp_integer_t* b);
 
 /**
  * Compute sum_product += a*b in the given ring.
  */
-void lp_integer_add_mul_int(lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, int b);
+void lp_integer_add_mul_int(const lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, int b);
 
 /**
  * Compute sub_product -= a*b in the given ring.
  */
-void lp_integer_sub_mul(lp_int_ring_t* K, lp_integer_t* sub_product, const lp_integer_t* a, const lp_integer_t* b);
+void lp_integer_sub_mul(const lp_int_ring_t* K, lp_integer_t* sub_product, const lp_integer_t* a, const lp_integer_t* b);
 
 /**
  * Compute a = div*b, in the given ring (assumes that b divides a).
  */
-void lp_integer_div_exact(lp_int_ring_t* K, lp_integer_t* div_Z, const lp_integer_t* a, const lp_integer_t* b);
+void lp_integer_div_exact(const lp_int_ring_t* K, lp_integer_t* div_Z, const lp_integer_t* a, const lp_integer_t* b);
 
 /**
  * Compute a = div*b + rem, rounding div towards zero, and r will have the

--- a/src/number/integer.c
+++ b/src/number/integer.c
@@ -107,27 +107,27 @@ void lp_integer_construct(lp_integer_t* c) {
   integer_construct(c);
 }
 
-void lp_integer_construct_from_rational(lp_int_ring_t* K, lp_integer_t* c, const lp_rational_t* q) {
+void lp_integer_construct_from_rational(const lp_int_ring_t* K, lp_integer_t* c, const lp_rational_t* q) {
   integer_construct_from_rational(K, c, q);
 }
 
-void lp_integer_construct_from_int(lp_int_ring_t* K, lp_integer_t* c, long x) {
+void lp_integer_construct_from_int(const lp_int_ring_t* K, lp_integer_t* c, long x) {
   integer_construct_from_int(K, c, x);
 }
 
-void lp_integer_construct_from_string(lp_int_ring_t* K, lp_integer_t* c, const char* x, int base) {
+void lp_integer_construct_from_string(const lp_int_ring_t* K, lp_integer_t* c, const char* x, int base) {
   integer_construct_from_string(K, c, x, base);
 }
 
-void lp_integer_construct_copy(lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from) {
+void lp_integer_construct_copy(const lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from) {
   integer_construct_copy(K, c, from);
 }
 
-void lp_integer_assign(lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from) {
+void lp_integer_assign(const lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from) {
   integer_assign(K, c, from);
 }
 
-void lp_integer_assign_int(lp_int_ring_t* K, lp_integer_t* c, long x) {
+void lp_integer_assign_int(const lp_int_ring_t* K, lp_integer_t* c, long x) {
   integer_assign_int(K, c, x);
 }
 
@@ -163,27 +163,27 @@ int lp_integer_is_prime(const lp_integer_t* c) {
   return integer_is_prime(c);
 }
 
-int lp_integer_is_zero(lp_int_ring_t* K, const lp_integer_t* c) {
+int lp_integer_is_zero(const lp_int_ring_t* K, const lp_integer_t* c) {
   return integer_is_zero(K, c);
 }
 
-int lp_integer_in_ring(lp_int_ring_t* K, const lp_integer_t* c) {
+int lp_integer_in_ring(const lp_int_ring_t* K, const lp_integer_t* c) {
   return integer_in_ring(K, c);
 }
 
-int lp_integer_sgn(lp_int_ring_t* K, const lp_integer_t* c) {
+int lp_integer_sgn(const lp_int_ring_t* K, const lp_integer_t* c) {
   return integer_sgn(K, c);
 }
 
-int lp_integer_cmp(lp_int_ring_t* K, const lp_integer_t* c, const lp_integer_t* to) {
+int lp_integer_cmp(const lp_int_ring_t* K, const lp_integer_t* c, const lp_integer_t* to) {
   return integer_cmp(K, c, to);
 }
 
-int lp_integer_cmp_int(lp_int_ring_t* K, const lp_integer_t* c, long to) {
+int lp_integer_cmp_int(const lp_int_ring_t* K, const lp_integer_t* c, long to) {
   return integer_cmp_int(K, c, to);
 }
 
-int lp_integer_divides(lp_int_ring_t* K, const lp_integer_t* a, const lp_integer_t* b) {
+int lp_integer_divides(const lp_int_ring_t* K, const lp_integer_t* a, const lp_integer_t* b) {
   return integer_divides(K, a, b);
 }
 
@@ -191,47 +191,47 @@ void lp_integer_swap(lp_integer_t* a, lp_integer_t* b) {
   integer_swap(a, b);
 }
 
-void lp_integer_inc(lp_int_ring_t* K, lp_integer_t* a) {
+void lp_integer_inc(const lp_int_ring_t* K, lp_integer_t* a) {
   integer_inc(K, a);
 }
 
-void lp_integer_dec(lp_int_ring_t* K, lp_integer_t* a) {
+void lp_integer_dec(const lp_int_ring_t* K, lp_integer_t* a) {
   integer_dec(K, a);
 }
 
-void lp_integer_add(lp_int_ring_t* K, lp_integer_t* sum, const lp_integer_t* a, const lp_integer_t* b) {
+void lp_integer_add(const lp_int_ring_t* K, lp_integer_t* sum, const lp_integer_t* a, const lp_integer_t* b) {
   integer_add(K, sum, a, b);
 }
 
-void lp_integer_sub(lp_int_ring_t* K, lp_integer_t* sub, const lp_integer_t* a, const lp_integer_t* b) {
+void lp_integer_sub(const lp_int_ring_t* K, lp_integer_t* sub, const lp_integer_t* a, const lp_integer_t* b) {
   integer_sub(K, sub, a, b);
 }
 
-void lp_integer_neg(lp_int_ring_t* K, lp_integer_t* neg, const lp_integer_t* a) {
+void lp_integer_neg(const lp_int_ring_t* K, lp_integer_t* neg, const lp_integer_t* a) {
   integer_neg(K, neg, a);
 }
 
-void lp_integer_abs(lp_int_ring_t* K, lp_integer_t* abs, const lp_integer_t* a) {
+void lp_integer_abs(const lp_int_ring_t* K, lp_integer_t* abs, const lp_integer_t* a) {
   integer_abs(K, abs, a);
 }
 
-void lp_integer_inv(lp_int_ring_t* K, lp_integer_t* inv, const lp_integer_t* a) {
+void lp_integer_inv(const lp_int_ring_t* K, lp_integer_t* inv, const lp_integer_t* a) {
   integer_inv(K, inv, a);
 }
 
-void lp_integer_mul(lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, const lp_integer_t* b) {
+void lp_integer_mul(const lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, const lp_integer_t* b) {
   integer_mul(K, product, a, b);
 }
 
-void lp_integer_mul_int(lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, long b) {
+void lp_integer_mul_int(const lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, long b) {
   integer_mul_int(K, product, a, b);
 }
 
-void lp_integer_mul_pow2(lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, unsigned n) {
+void lp_integer_mul_pow2(const lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, unsigned n) {
   integer_mul_pow2(K, product, a, n);
 }
 
-void lp_integer_pow(lp_int_ring_t* K, lp_integer_t* pow, const lp_integer_t *a, unsigned n) {
+void lp_integer_pow(const lp_int_ring_t* K, lp_integer_t* pow, const lp_integer_t *a, unsigned n) {
   integer_pow(K, pow, a, n);
 }
 
@@ -239,19 +239,19 @@ void lp_integer_sqrt_Z(lp_integer_t* sqrt, const lp_integer_t* a) {
   integer_sqrt_Z(sqrt, a);
 }
 
-void lp_integer_add_mul(lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, const lp_integer_t* b) {
+void lp_integer_add_mul(const lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, const lp_integer_t* b) {
   integer_add_mul(K, sum_product, a, b);
 }
 
-void lp_integer_add_mul_int(lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, int b) {
+void lp_integer_add_mul_int(const lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, int b) {
   integer_add_mul_int(K, sum_product, a, b);
 }
 
-void lp_integer_sub_mul(lp_int_ring_t* K, lp_integer_t* sub_product, const lp_integer_t* a, const lp_integer_t* b) {
+void lp_integer_sub_mul(const lp_int_ring_t* K, lp_integer_t* sub_product, const lp_integer_t* a, const lp_integer_t* b) {
   integer_sub_mul(K, sub_product, a, b);
 }
 
-void lp_integer_div_exact(lp_int_ring_t* K, lp_integer_t* div_Z, const lp_integer_t* a, const lp_integer_t* b) {
+void lp_integer_div_exact(const lp_int_ring_t* K, lp_integer_t* div_Z, const lp_integer_t* a, const lp_integer_t* b) {
   integer_div_exact(K, div_Z, a, b);
 }
 

--- a/src/number/integer.h
+++ b/src/number/integer.h
@@ -31,7 +31,7 @@
 #define __var_unused(x) ((void)x)
 
 static inline
-int integer_in_ring(lp_int_ring_t* K, const lp_integer_t* c) {
+int integer_in_ring(const lp_int_ring_t* K, const lp_integer_t* c) {
   if (K) {
     int sgn = mpz_sgn(c);
     if (sgn == 0) return 1;
@@ -45,7 +45,7 @@ int integer_in_ring(lp_int_ring_t* K, const lp_integer_t* c) {
 }
 
 inline static
-void integer_ring_normalize(lp_int_ring_t* K, lp_integer_t* c) {
+void integer_ring_normalize(const lp_int_ring_t* K, lp_integer_t* c) {
   if (K && !integer_in_ring(K, c)) {
     // Remainder
     lp_integer_t tmp;
@@ -79,38 +79,38 @@ void integer_construct(lp_integer_t* c) {
 }
 
 static inline
-void integer_construct_from_rational(lp_int_ring_t* K, lp_integer_t* c, const lp_rational_t* q) {
+void integer_construct_from_rational(const lp_int_ring_t* K, lp_integer_t* c, const lp_rational_t* q) {
   mpz_init(c);
   mpq_get_num(c, q);
   integer_ring_normalize(K, c);
 }
 
 static inline
-void integer_construct_from_int(lp_int_ring_t* K, lp_integer_t* c, long x) {
+void integer_construct_from_int(const lp_int_ring_t* K, lp_integer_t* c, long x) {
   mpz_init_set_si(c, x);
   integer_ring_normalize(K, c);
 }
 
 static inline
-void integer_construct_from_string(lp_int_ring_t* K, lp_integer_t* c, const char* x, int base) {
+void integer_construct_from_string(const lp_int_ring_t* K, lp_integer_t* c, const char* x, int base) {
   mpz_init_set_str(c, x, base);
   integer_ring_normalize(K, c);
 }
 
 static inline
-void integer_construct_copy(lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from) {
+void integer_construct_copy(const lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from) {
   mpz_init_set(c, from);
   integer_ring_normalize(K, c);
 }
 
 static inline
-void integer_assign(lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from) {
+void integer_assign(const lp_int_ring_t* K, lp_integer_t* c, const lp_integer_t* from) {
   mpz_set(c, from);
   integer_ring_normalize(K, c);
 }
 
 static inline
-void integer_assign_int(lp_int_ring_t* K, lp_integer_t* c, long from) {
+void integer_assign_int(const lp_int_ring_t* K, lp_integer_t* c, long from) {
   mpz_set_si(c, from);
   integer_ring_normalize(K, c);
 }
@@ -169,7 +169,7 @@ int integer_is_prime(const lp_integer_t* c) {
 }
 
 static inline
-int integer_is_zero(lp_int_ring_t* K, const lp_integer_t* c) {
+int integer_is_zero(const lp_int_ring_t* K, const lp_integer_t* c) {
   if (K) {
     lp_integer_t c_normalized;
     integer_construct_copy(K, &c_normalized, c);
@@ -182,7 +182,7 @@ int integer_is_zero(lp_int_ring_t* K, const lp_integer_t* c) {
 }
 
 static inline
-int integer_sgn(lp_int_ring_t* K, const lp_integer_t* c) {
+int integer_sgn(const lp_int_ring_t* K, const lp_integer_t* c) {
   if (K) {
     lp_integer_t c_normalized;
     integer_construct_copy(K, &c_normalized, c);
@@ -195,7 +195,7 @@ int integer_sgn(lp_int_ring_t* K, const lp_integer_t* c) {
 }
 
 static inline
-int integer_cmp(lp_int_ring_t* K, const lp_integer_t* c, const lp_integer_t* to) {
+int integer_cmp(const lp_int_ring_t* K, const lp_integer_t* c, const lp_integer_t* to) {
   if (K) {
     lp_integer_t c_normalized, to_normalized;
     integer_construct_copy(K, &c_normalized, c);
@@ -210,7 +210,7 @@ int integer_cmp(lp_int_ring_t* K, const lp_integer_t* c, const lp_integer_t* to)
 }
 
 static inline
-int integer_cmp_int(lp_int_ring_t* K, const lp_integer_t* c, long to) {
+int integer_cmp_int(const lp_int_ring_t* K, const lp_integer_t* c, long to) {
   if (K) {
     lp_integer_t c_normalized, to_normalized;
     integer_construct_copy(K, &c_normalized, c);
@@ -225,7 +225,7 @@ int integer_cmp_int(lp_int_ring_t* K, const lp_integer_t* c, long to) {
 }
 
 static inline
-int integer_divides(lp_int_ring_t* K, const lp_integer_t* a, const lp_integer_t* b) {
+int integer_divides(const lp_int_ring_t* K, const lp_integer_t* a, const lp_integer_t* b) {
   assert(integer_in_ring(K, a) && integer_in_ring(K, b));
   if (K) {
     // In a prime ring, it's always divisible
@@ -248,7 +248,7 @@ void integer_swap(lp_integer_t* a, lp_integer_t* b) {
 }
 
 static inline
-void integer_inc(lp_int_ring_t* K, lp_integer_t* a) {
+void integer_inc(const lp_int_ring_t* K, lp_integer_t* a) {
   assert(integer_in_ring(K, a));
   lp_integer_t tmp;
   mpz_init(&tmp);
@@ -259,7 +259,7 @@ void integer_inc(lp_int_ring_t* K, lp_integer_t* a) {
 }
 
 static inline
-void integer_dec(lp_int_ring_t* K, lp_integer_t* a) {
+void integer_dec(const lp_int_ring_t* K, lp_integer_t* a) {
   assert(integer_in_ring(K, a));
   lp_integer_t tmp;
   mpz_init(&tmp);
@@ -270,35 +270,35 @@ void integer_dec(lp_int_ring_t* K, lp_integer_t* a) {
 }
 
 static inline
-void integer_add(lp_int_ring_t* K, lp_integer_t* sum, const lp_integer_t* a, const lp_integer_t* b) {
+void integer_add(const lp_int_ring_t* K, lp_integer_t* sum, const lp_integer_t* a, const lp_integer_t* b) {
   assert(integer_in_ring(K, a) && integer_in_ring(K, b));
   mpz_add(sum, a, b);
   integer_ring_normalize(K, sum);
 }
 
 static inline
-void integer_sub(lp_int_ring_t* K, lp_integer_t* sub, const lp_integer_t* a, const lp_integer_t* b) {
+void integer_sub(const lp_int_ring_t* K, lp_integer_t* sub, const lp_integer_t* a, const lp_integer_t* b) {
   assert(integer_in_ring(K, a) && integer_in_ring(K, b));
   mpz_sub(sub, a, b);
   integer_ring_normalize(K, sub);
 }
 
 static inline
-void integer_neg(lp_int_ring_t* K, lp_integer_t* neg, const lp_integer_t* a) {
+void integer_neg(const lp_int_ring_t* K, lp_integer_t* neg, const lp_integer_t* a) {
   assert(integer_in_ring(K, a));
   mpz_neg(neg, a);
   integer_ring_normalize(K, neg);
 }
 
 static inline
-void integer_abs(lp_int_ring_t* K, lp_integer_t* abs, const lp_integer_t* a) {
+void integer_abs(const lp_int_ring_t* K, lp_integer_t* abs, const lp_integer_t* a) {
   assert(integer_in_ring(K, a));
   mpz_abs(abs, a);
   integer_ring_normalize(K, abs);
 }
 
 static inline
-void integer_inv(lp_int_ring_t* K, lp_integer_t* inv, const lp_integer_t* a) {
+void integer_inv(const lp_int_ring_t* K, lp_integer_t* inv, const lp_integer_t* a) {
   assert(K);
   assert(integer_in_ring(K, a));
   int result = mpz_invert(inv, a, &K->M);
@@ -308,28 +308,28 @@ void integer_inv(lp_int_ring_t* K, lp_integer_t* inv, const lp_integer_t* a) {
 }
 
 static inline
-void integer_mul(lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, const lp_integer_t* b) {
+void integer_mul(const lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, const lp_integer_t* b) {
   assert(integer_in_ring(K, a) && integer_in_ring(K, b));
   mpz_mul(product, a, b);
   integer_ring_normalize(K, product);
 }
 
 static inline
-void integer_mul_int(lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, long b) {
+void integer_mul_int(const lp_int_ring_t* K, lp_integer_t* product, const lp_integer_t* a, long b) {
   assert(integer_in_ring(K, a));
   mpz_mul_si(product, a, b);
   integer_ring_normalize(K, product);
 }
 
 static inline
-void integer_mul_pow2(lp_int_ring_t* K, lp_integer_t* power, const lp_integer_t* a, unsigned n) {
+void integer_mul_pow2(const lp_int_ring_t* K, lp_integer_t* power, const lp_integer_t* a, unsigned n) {
   assert(integer_in_ring(K, a));
   mpz_mul_2exp(power, a, n);
   integer_ring_normalize(K, power);
 }
 
 static inline
-void integer_pow(lp_int_ring_t* K, lp_integer_t* power, const lp_integer_t*a, unsigned n) {
+void integer_pow(const lp_int_ring_t* K, lp_integer_t* power, const lp_integer_t*a, unsigned n) {
   assert(integer_in_ring(K, a));
   if (K) {
     mpz_powm_ui(power, a, n, &K->M);
@@ -350,21 +350,21 @@ void integer_sqrt_rem_Z(lp_integer_t* sqrt, lp_integer_t* rem, const lp_integer_
 }
 
 static inline
-void integer_add_mul(lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, const lp_integer_t* b) {
+void integer_add_mul(const lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, const lp_integer_t* b) {
   assert(integer_in_ring(K, sum_product) && integer_in_ring(K, a) && integer_in_ring(K, b));
   mpz_addmul(sum_product, a, b);
   integer_ring_normalize(K, sum_product);
 }
 
 static inline
-void integer_sub_mul(lp_int_ring_t* K, lp_integer_t* sub_product, const lp_integer_t* a, const lp_integer_t* b) {
+void integer_sub_mul(const lp_int_ring_t* K, lp_integer_t* sub_product, const lp_integer_t* a, const lp_integer_t* b) {
   assert(integer_in_ring(K, sub_product) && integer_in_ring(K, a) && integer_in_ring(K, b));
   mpz_submul(sub_product, a, b);
   integer_ring_normalize(K, sub_product);
 }
 
 static inline
-void integer_add_mul_int(lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, int b) {
+void integer_add_mul_int(const lp_int_ring_t* K, lp_integer_t* sum_product, const lp_integer_t* a, int b) {
   assert(integer_in_ring(K, sum_product));
   assert(integer_in_ring(K, a));
   if (b > 0) {
@@ -376,7 +376,7 @@ void integer_add_mul_int(lp_int_ring_t* K, lp_integer_t* sum_product, const lp_i
 }
 
 static inline
-void integer_div_exact(lp_int_ring_t* K, lp_integer_t* div, const lp_integer_t* a, const lp_integer_t* b) {
+void integer_div_exact(const lp_int_ring_t* K, lp_integer_t* div, const lp_integer_t* a, const lp_integer_t* b) {
   assert(integer_in_ring(K, a) && integer_in_ring(K, b));
   if (K) {
     // Solving a = div*b (mod M). Let d = gcd(b, M) with extended gcd, we have


### PR DESCRIPTION
This adds a const for `lp_int_ring_t*` arguments almost everywhere.
The exceptions are `lp_int_ring_attach` and `lp_int_ring_detach` which actually intend to modify the ring. Note however, that they internally (attempt to?) do a cast to a non-const pointer anyway, which seems unnecessary.