### PR TITLE
Properly scale upper bound in lp_dyadic_interval_scale() for negative n.

### DIFF
--- a/src/interval/interval.c
+++ b/src/interval/interval.c
@@ -891,7 +891,7 @@ void lp_dyadic_interval_scale(lp_dyadic_interval_t* I, int n) {
     dyadic_rational_mul_2exp(&I->b, &I->b, n);
   } else {
     dyadic_rational_div_2exp(&I->a, &I->a, -n);
-    dyadic_rational_div_2exp(&I->a, &I->a, -n);
+    dyadic_rational_div_2exp(&I->b, &I->b, -n);
   }
 }
 


### PR DESCRIPTION
I found that `lp_dyadic_interval_scale` does not work properly for negative `n`. This PR fixes this issue.