### PR TITLE
Fix contains_zero check for upper bound.

### DIFF
--- a/src/interval/interval.c
+++ b/src/interval/interval.c
@@ -708,8 +708,8 @@ int lp_dyadic_interval_contains_zero(const lp_dyadic_interval_t* I) {
   if (I->a_open && sgn_a >= 0) return 0;
   if (!I->a_open && sgn_a > 0) return 0;
   int sgn_b = dyadic_rational_sgn(&I->b);
-  if (I->b_open && sgn_b < 0) return 0;
-  if (!I->b_open && sgn_b <= 0) return 0;
+  if (I->b_open && sgn_b <= 0) return 0;
+  if (!I->b_open && sgn_b < 0) return 0;
   return 1;
 }
 


### PR DESCRIPTION
`lp_dyadic_interval_contains_zero` yields incorrect results if the upper bound happens to be zero.
Check, for example, with `(-1 ; 0)` and `(-1 ; 0]`. Also compare against the implementation of `lp_rational_interval_contains_zero`...