### PR TITLE
Made usage of lp_int_ring_t* const at more places.

### DIFF
--- a/include/upolynomial.h
+++ b/include/upolynomial.h
@@ -33,24 +33,24 @@ extern "C" {
  * Construct the polynomial given its coefficients. Coefficients should be
  * indexed by degree and they will be normalized according to the given ring.
  */
-lp_upolynomial_t* lp_upolynomial_construct(lp_int_ring_t* K, size_t degree, const lp_integer_t* coefficients);
+lp_upolynomial_t* lp_upolynomial_construct(const lp_int_ring_t* K, size_t degree, const lp_integer_t* coefficients);
 
 /**
  * Construct the polynomial c*x^d.
  */
-lp_upolynomial_t* lp_upolynomial_construct_power(lp_int_ring_t* K, size_t degree, long c);
+lp_upolynomial_t* lp_upolynomial_construct_power(const lp_int_ring_t* K, size_t degree, long c);
 
 /**
  * Construct the polynomial given its coefficients. Coefficients should be
  * indexed by degree and they will be normalize according to the given ring.
  */
-lp_upolynomial_t* lp_upolynomial_construct_from_int(lp_int_ring_t* K, size_t degree, const int* coefficients);
+lp_upolynomial_t* lp_upolynomial_construct_from_int(const lp_int_ring_t* K, size_t degree, const int* coefficients);
 
 /**
  * Construct the polynomial given its coefficients. Coefficients should be
  * indexed by degree and they will be normalize according to the given ring.
  */
-lp_upolynomial_t* lp_upolynomial_construct_from_long(lp_int_ring_t* K, size_t degree, const long* coefficients);
+lp_upolynomial_t* lp_upolynomial_construct_from_long(const lp_int_ring_t* K, size_t degree, const long* coefficients);
 
 /**
  * Construct a copy of the polynomial.
@@ -60,7 +60,7 @@ lp_upolynomial_t* lp_upolynomial_construct_copy(const lp_upolynomial_t* p);
 /**
  * Construct a copy of the polynomial, but change the ring.
  */
-lp_upolynomial_t* lp_upolynomial_construct_copy_K(lp_int_ring_t* K, const lp_upolynomial_t* p);
+lp_upolynomial_t* lp_upolynomial_construct_copy_K(const lp_int_ring_t* K, const lp_upolynomial_t* p);
 
 /**
  * Frees the polynomial data and detaches the ring. */
@@ -75,12 +75,12 @@ size_t lp_upolynomial_degree(const lp_upolynomial_t* p);
 /**
  * Returns the field of the polynomial (unatached).
  */
-lp_int_ring_t* lp_upolynomial_ring(const lp_upolynomial_t* p);
+const lp_int_ring_t* lp_upolynomial_ring(const lp_upolynomial_t* p);
 
 /**
  * Sets the ring to given ring (has to be "larger" than existing).
  */
-void lp_upolynomial_set_ring(lp_upolynomial_t* p, lp_int_ring_t* K);
+void lp_upolynomial_set_ring(lp_upolynomial_t* p, const lp_int_ring_t* K);
 
 /**
  * Returns the lead coefficient of the given polynomial.

--- a/include/upolynomial_factors.h
+++ b/include/upolynomial_factors.h
@@ -58,13 +58,13 @@ void lp_upolynomial_factors_add(lp_upolynomial_factors_t* f, lp_upolynomial_t* p
 int lp_upolynomial_factors_print(const lp_upolynomial_factors_t* f, FILE* out);
 
 /** Get the ring */
-lp_int_ring_t* lp_upolynomial_factors_ring(const lp_upolynomial_factors_t* f);
+const lp_int_ring_t* lp_upolynomial_factors_ring(const lp_upolynomial_factors_t* f);
 
 /**
  * Set the ring of all polynomials to K. This is only possible if K is
  * "larger" than the existing ring.
  */
-void lp_upolynomial_factors_set_ring(lp_upolynomial_factors_t* f, lp_int_ring_t* K);
+void lp_upolynomial_factors_set_ring(lp_upolynomial_factors_t* f, const lp_int_ring_t* K);
 
 #ifdef __cplusplus
 } /* close extern "C" { */

--- a/python/polypyInteger.h
+++ b/python/polypyInteger.h
@@ -37,7 +37,7 @@ extern PyMethodDef CoefficientRing_methods[];
 extern PyTypeObject CoefficientRingType;
 
 /** Create a ring object */
-PyObject* PyCoefficientRing_create(lp_int_ring_t* K);
+PyObject* PyCoefficientRing_create(const lp_int_ring_t* K);
 
 /** Check if the object is a polynomial */
 #define PyCoefficientRing_CHECK(arg) \

--- a/python/polypyInteger2.c
+++ b/python/polypyInteger2.c
@@ -94,7 +94,7 @@ CoefficientRing_dealloc(CoefficientRing* self)
 }
 
 PyObject*
-PyCoefficientRing_create(lp_int_ring_t* K) {
+PyCoefficientRing_create(const lp_int_ring_t* K) {
   CoefficientRing *self;
   self = (CoefficientRing*)CoefficientRingType.tp_alloc(&CoefficientRingType, 0);
   if (self != NULL) {

--- a/python/polypyInteger3.c
+++ b/python/polypyInteger3.c
@@ -104,11 +104,11 @@ CoefficientRing_dealloc(CoefficientRing* self)
 }
 
 PyObject*
-PyCoefficientRing_create(lp_int_ring_t* K) {
+PyCoefficientRing_create(const lp_int_ring_t* K) {
   CoefficientRing *self;
   self = (CoefficientRing*)CoefficientRingType.tp_alloc(&CoefficientRingType, 0);
   if (self != NULL) {
-    self->K = K;
+    self->K = (lp_int_ring_t*)K;
   }
   return (PyObject *)self;
 }

--- a/python/polypyUPolynomial3.c
+++ b/python/polypyUPolynomial3.c
@@ -309,7 +309,7 @@ UPolynomial_richcompare(PyObject* self, PyObject* other, int op) {
       other_p = ((UPolynomialObject*) other)->p;
     } else {
       long c = PyLong_AsLong(other);
-      lp_int_ring_t* K = lp_upolynomial_ring(self_p);
+      const lp_int_ring_t* K = lp_upolynomial_ring(self_p);
       other_p = lp_upolynomial_construct_from_long(K, 0, &c);
     }
 
@@ -384,8 +384,8 @@ static PyObject*
 UPolynomial_ring(PyObject* self) {
   UPolynomialObject* p = (UPolynomialObject*) self;
   if (p) {
-    lp_int_ring_t* K = lp_upolynomial_ring(p->p);
-    lp_int_ring_attach(K);
+    const lp_int_ring_t* K = lp_upolynomial_ring(p->p);
+    lp_int_ring_attach((lp_int_ring_t*)K);
     return PyCoefficientRing_create(K);
   } else {
     Py_RETURN_NONE;
@@ -432,7 +432,7 @@ static PyObject*
 UPolynomialObject_add_number(PyObject* self, PyObject* other) {
   UPolynomialObject* p1 = (UPolynomialObject*) self;
   lp_integer_t c;
-  lp_int_ring_t* K = lp_upolynomial_ring(p1->p);
+  const lp_int_ring_t* K = lp_upolynomial_ring(p1->p);
   PyLong_or_Int_to_integer(other, K, &c);
   lp_upolynomial_t* c_p = lp_upolynomial_construct(K, 0, &c);
   lp_upolynomial_t* sum = lp_upolynomial_add(p1->p, c_p);
@@ -468,7 +468,7 @@ static PyObject*
 UPolynomialObject_sub_int(PyObject* self, PyObject* other, int negate) {
   UPolynomialObject* p1 = (UPolynomialObject*) self;
   lp_integer_t c;
-  lp_int_ring_t* K = lp_upolynomial_ring(p1->p);
+  const lp_int_ring_t* K = lp_upolynomial_ring(p1->p);
   PyLong_or_Int_to_integer(other, K, &c);
   lp_upolynomial_t* c_p = lp_upolynomial_construct(K, 0, &c);
   lp_upolynomial_t* sub =

--- a/python/utils.h
+++ b/python/utils.h
@@ -48,7 +48,7 @@ int PyLong_or_Int_Check(PyObject* o);
 /**
  * Construct the integer from pytong Long or int.
  */
-void PyLong_or_Int_to_integer(PyObject* o, lp_int_ring_t* K, lp_integer_t* x);
+void PyLong_or_Int_to_integer(PyObject* o, const lp_int_ring_t* K, lp_integer_t* x);
 
 /**
  * Get a python integer (or long) from our integer.

--- a/python/utils2.c
+++ b/python/utils2.c
@@ -43,7 +43,7 @@ int PyLong_or_Int_Check(PyObject* o) {
   return 0;
 }
 
-void PyLong_or_Int_to_integer(PyObject* o, lp_int_ring_t* K, lp_integer_t* c) {
+void PyLong_or_Int_to_integer(PyObject* o, const lp_int_ring_t* K, lp_integer_t* c) {
   if (PyInt_Check(o)) {
     long c_long  = PyInt_AsLong(o);
     lp_integer_construct_from_int(K, c, c_long);

--- a/python/utils3.c
+++ b/python/utils3.c
@@ -47,7 +47,7 @@ int PyLong_or_Int_Check(PyObject* o) {
   return 0;
 }
 
-void PyLong_or_Int_to_integer(PyObject* o, lp_int_ring_t* K, lp_integer_t* c) {
+void PyLong_or_Int_to_integer(PyObject* o, const lp_int_ring_t* K, lp_integer_t* c) {
   if (PyLong_Check(o)) {
     long c_long  = PyLong_AsLong(o);
     lp_integer_construct_from_int(K, c, c_long);

--- a/src/upolynomial/factorization.c
+++ b/src/upolynomial/factorization.c
@@ -278,7 +278,7 @@ lp_upolynomial_factors_t* upolynomial_factor_distinct_degree(const lp_upolynomia
   }
   STAT_INCR(upolynomial, factor_distinct_degree)
 
-  lp_int_ring_t* K = f->K;
+  const lp_int_ring_t* K = f->K;
   assert(K && K->is_prime);
   assert(lp_upolynomial_is_monic(f));
 
@@ -363,7 +363,7 @@ lp_upolynomial_factors_t* upolynomial_factor_distinct_degree(const lp_upolynomia
 
 static void Q_construct(lp_integer_t* Q, size_t size, const lp_upolynomial_t* u) {
 
-  lp_int_ring_t* K = lp_upolynomial_ring(u);
+  const lp_int_ring_t* K = lp_upolynomial_ring(u);
   size_t p = (size_t) integer_to_int(&K->M);
 
   size_t k;
@@ -393,7 +393,7 @@ static void Q_construct(lp_integer_t* Q, size_t size, const lp_upolynomial_t* u)
   integer_destruct(&tmp); integer_destruct(&one);
 }
 
-static void Q_column_multiply(lp_int_ring_t* K, lp_integer_t* Q, size_t size, int j, const lp_integer_t* m) {
+static void Q_column_multiply(const lp_int_ring_t* K, lp_integer_t* Q, size_t size, int j, const lp_integer_t* m) {
 
   if (trace_is_enabled("nullspace")) {
     tracef("Multiplying column %d of Q with ", j); integer_print(m, trace_out); tracef("\n");
@@ -417,7 +417,7 @@ static void Q_column_multiply(lp_int_ring_t* K, lp_integer_t* Q, size_t size, in
 }
 
 // add column j into i multiplied by m
-static void Q_column_add(lp_int_ring_t* K, lp_integer_t* Q, size_t size, int i, const lp_integer_t* m, int j) {
+static void Q_column_add(const lp_int_ring_t* K, lp_integer_t* Q, size_t size, int i, const lp_integer_t* m, int j) {
 
   assert(i != j);
 
@@ -453,7 +453,7 @@ static void Q_column_add(lp_int_ring_t* K, lp_integer_t* Q, size_t size, int i, 
   }
 }
 
-static void Q_null_space(lp_int_ring_t* K, lp_integer_t* Q, size_t size, lp_integer_t** v, size_t* v_size) {
+static void Q_null_space(const lp_int_ring_t* K, lp_integer_t* Q, size_t size, lp_integer_t** v, size_t* v_size) {
 
   *v_size = 0;
 
@@ -595,7 +595,7 @@ lp_upolynomial_factors_t* upolynomial_factor_berlekamp_square_free(const lp_upol
 
   // Polynomial to factor and it's degree
   size_t deg_f = lp_upolynomial_degree(f);
-  lp_int_ring_t* K = lp_upolynomial_ring(f);
+  const lp_int_ring_t* K = lp_upolynomial_ring(f);
 
   // If degree < 2 we're done
   if (deg_f < 2) {
@@ -721,7 +721,7 @@ lp_upolynomial_factors_t* upolynomial_factor_Zp(const lp_upolynomial_t* f) {
     tracef("upolynomial_factor_Zp("); lp_upolynomial_print(f, trace_out); tracef(")\n");
   }
 
-  lp_int_ring_t* K = f->K;
+  const lp_int_ring_t* K = f->K;
 
   assert(K && K->is_prime);
   assert(lp_upolynomial_degree(f) > 0);
@@ -857,7 +857,7 @@ void hensel_lift_initialize(const lp_upolynomial_factors_t* A, lp_upolynomial_fa
   // The number of factors
   const int r = A->size;
 
-  lp_int_ring_t* K = lp_upolynomial_factors_ring(A);
+  const lp_int_ring_t* K = lp_upolynomial_factors_ring(A);
 
   // All the Q_i = A_i*...*A_r
   lp_upolynomial_t* Q[r];
@@ -1018,7 +1018,7 @@ void hensel_lift_quadratic(const lp_upolynomial_t* F,
   assert(V->size == 0);
 
   // The ring we are lifting
-  lp_int_ring_t* Zq = A->factors[0]->K;
+  const lp_int_ring_t* Zq = A->factors[0]->K;
   // The modulus
   const lp_integer_t* q = &Zq->M;
 

--- a/src/upolynomial/factors.c
+++ b/src/upolynomial/factors.c
@@ -87,7 +87,7 @@ void lp_upolynomial_factors_add(lp_upolynomial_factors_t* f, lp_upolynomial_t* p
   f->size ++;
 }
 
-lp_int_ring_t* lp_upolynomial_factors_ring(const lp_upolynomial_factors_t* f) {
+const lp_int_ring_t* lp_upolynomial_factors_ring(const lp_upolynomial_factors_t* f) {
   if (f->size == 0) {
     return lp_Z;
   } else {
@@ -95,7 +95,7 @@ lp_int_ring_t* lp_upolynomial_factors_ring(const lp_upolynomial_factors_t* f) {
   }
 }
 
-void lp_upolynomial_factors_set_ring(lp_upolynomial_factors_t* f, lp_int_ring_t* K) {
+void lp_upolynomial_factors_set_ring(lp_upolynomial_factors_t* f, const lp_int_ring_t* K) {
   size_t i;
   for (i = 0; i < f->size; ++ i) {
     lp_upolynomial_set_ring(f->factors[i], K);

--- a/src/upolynomial/gcd.c
+++ b/src/upolynomial/gcd.c
@@ -96,7 +96,7 @@ lp_upolynomial_t* upolynomial_gcd_euclid(const lp_upolynomial_t* A, const lp_upo
 
   // The ring of computation
   assert(A->K == B->K);
-  lp_int_ring_t* K = A->K;
+  const lp_int_ring_t* K = A->K;
   assert(K && K->is_prime);
 
   // The remainder in the calculation
@@ -223,7 +223,7 @@ lp_upolynomial_t* upolynomial_gcd_subresultant(const lp_upolynomial_t* A, const 
   // The ring of compuation
   assert(A->K == B->K);
   assert(A->K == lp_Z);
-  lp_int_ring_t* K = A->K;
+  const lp_int_ring_t* K = A->K;
 
   // Degrees of p and q
   size_t deg_A = lp_upolynomial_degree(A);

--- a/src/upolynomial/umonomial.c
+++ b/src/upolynomial/umonomial.c
@@ -21,19 +21,19 @@
 
 #include <assert.h>
 
-void umonomial_construct(lp_int_ring_t* K, ulp_monomial_t* m, size_t degree, const lp_integer_t* coefficient) {
+void umonomial_construct(const lp_int_ring_t* K, ulp_monomial_t* m, size_t degree, const lp_integer_t* coefficient) {
   m->degree = degree;
   integer_construct_copy(K, &m->coefficient, coefficient);
   assert(m->degree == 0 || integer_sgn(lp_Z, &m->coefficient));
 }
 
-void umonomial_construct_from_int(lp_int_ring_t* K, ulp_monomial_t* m, size_t degree, long coefficient) {
+void umonomial_construct_from_int(const lp_int_ring_t* K, ulp_monomial_t* m, size_t degree, long coefficient) {
   m->degree = degree;
   integer_construct_from_int(K, &m->coefficient, coefficient);
   assert(m->degree == 0 || integer_sgn(lp_Z, &m->coefficient));
 }
 
-void umonomial_construct_copy(lp_int_ring_t* K, ulp_monomial_t* m, const ulp_monomial_t* from) {
+void umonomial_construct_copy(const lp_int_ring_t* K, ulp_monomial_t* m, const ulp_monomial_t* from) {
   assert(from);
   umonomial_construct(K, m, from->degree, &from->coefficient);
   assert(m->degree == 0 || integer_sgn(lp_Z, &m->coefficient));

--- a/src/upolynomial/umonomial.h
+++ b/src/upolynomial/umonomial.h
@@ -31,10 +31,10 @@ typedef struct umonomial_struct {
   lp_integer_t coefficient;
 } ulp_monomial_t;
 
-void umonomial_construct(lp_int_ring_t* K, ulp_monomial_t* m, size_t degree, const lp_integer_t* coefficient);
+void umonomial_construct(const lp_int_ring_t* K, ulp_monomial_t* m, size_t degree, const lp_integer_t* coefficient);
 
-void umonomial_construct_from_int(lp_int_ring_t* K, ulp_monomial_t* m, size_t degree, long coefficient);
+void umonomial_construct_from_int(const lp_int_ring_t* K, ulp_monomial_t* m, size_t degree, long coefficient);
 
-void umonomial_construct_copy(lp_int_ring_t* K, ulp_monomial_t* m, const ulp_monomial_t* from);
+void umonomial_construct_copy(const lp_int_ring_t* K, ulp_monomial_t* m, const ulp_monomial_t* from);
 
 void umonomial_destruct(ulp_monomial_t* m);

--- a/src/upolynomial/upolynomial.c
+++ b/src/upolynomial/upolynomial.c
@@ -43,16 +43,16 @@ size_t lp_upolynomial_degree(const lp_upolynomial_t* p) {
 }
 
 // Construct the polynomial, but don't construct monomials
-lp_upolynomial_t* lp_upolynomial_construct_empty(lp_int_ring_t* K, size_t size) {
+lp_upolynomial_t* lp_upolynomial_construct_empty(const lp_int_ring_t* K, size_t size) {
   size_t malloc_size = sizeof(lp_upolynomial_t) + size*sizeof(ulp_monomial_t);
   lp_upolynomial_t* new_p = (lp_upolynomial_t*) malloc(malloc_size);
-  new_p->K = K;
+  new_p->K = (lp_int_ring_t*)K;
   new_p->size = size;
   lp_int_ring_attach((lp_int_ring_t*)K);
   return new_p;
 }
 
-lp_upolynomial_t* lp_upolynomial_construct(lp_int_ring_t* K, size_t degree, const lp_integer_t* coefficients) {
+lp_upolynomial_t* lp_upolynomial_construct(const lp_int_ring_t* K, size_t degree, const lp_integer_t* coefficients) {
 
   // Compute the needed size
   unsigned i;
@@ -104,14 +104,14 @@ void lp_upolynomial_delete(lp_upolynomial_t* p) {
   free(p);
 }
 
-lp_upolynomial_t* lp_upolynomial_construct_power(lp_int_ring_t* K, size_t degree, long c) {
+lp_upolynomial_t* lp_upolynomial_construct_power(const lp_int_ring_t* K, size_t degree, long c) {
   lp_upolynomial_t* result = lp_upolynomial_construct_empty(K, 1);
   integer_construct_from_int(K, &result->monomials[0].coefficient, c);
   result->monomials[0].degree = degree;
   return result;
 }
 
-lp_upolynomial_t* lp_upolynomial_construct_from_int(lp_int_ring_t* K, size_t degree, const int* coefficients) {
+lp_upolynomial_t* lp_upolynomial_construct_from_int(const lp_int_ring_t* K, size_t degree, const int* coefficients) {
 
   unsigned i;
   lp_integer_t real_coefficients[degree+1];
@@ -129,7 +129,7 @@ lp_upolynomial_t* lp_upolynomial_construct_from_int(lp_int_ring_t* K, size_t deg
   return result;
 }
 
-lp_upolynomial_t* lp_upolynomial_construct_from_long(lp_int_ring_t* K, size_t degree, const long* coefficients) {
+lp_upolynomial_t* lp_upolynomial_construct_from_long(const lp_int_ring_t* K, size_t degree, const long* coefficients) {
 
   unsigned i;
   lp_integer_t real_coefficients[degree+1];
@@ -160,7 +160,7 @@ lp_upolynomial_t* lp_upolynomial_construct_copy(const lp_upolynomial_t* p) {
   return new_p;
 }
 
-lp_upolynomial_t* lp_upolynomial_construct_copy_K(lp_int_ring_t* K, const lp_upolynomial_t* p) {
+lp_upolynomial_t* lp_upolynomial_construct_copy_K(const lp_int_ring_t* K, const lp_upolynomial_t* p) {
 
   assert(p);
   assert(K != p->K);
@@ -169,7 +169,7 @@ lp_upolynomial_t* lp_upolynomial_construct_copy_K(lp_int_ring_t* K, const lp_upo
   if (K == lp_Z || (p->K != lp_Z && integer_cmp(lp_Z, &K->M, &p->K->M) >= 0)) {
     lp_upolynomial_t* copy = lp_upolynomial_construct_copy(p);
     lp_int_ring_detach(copy->K);
-    copy->K = K;
+    copy->K = (lp_int_ring_t*)K;
     lp_int_ring_attach(copy->K);
     return copy;
   }
@@ -227,15 +227,15 @@ void lp_upolynomial_unpack(const lp_upolynomial_t* p, lp_integer_t* out) {
   }
 }
 
-lp_int_ring_t* lp_upolynomial_ring(const lp_upolynomial_t* p) {
+const lp_int_ring_t* lp_upolynomial_ring(const lp_upolynomial_t* p) {
   assert(p);
   return p->K;
 }
 
-void lp_upolynomial_set_ring(lp_upolynomial_t* p, lp_int_ring_t* K) {
+void lp_upolynomial_set_ring(lp_upolynomial_t* p, const lp_int_ring_t* K) {
   assert(p);
   lp_int_ring_detach(p->K);
-  p->K = K;
+  p->K = (lp_int_ring_t*)K;
   lp_int_ring_attach(p->K);
 }
 
@@ -317,7 +317,7 @@ lp_upolynomial_t* lp_upolynomial_add(const lp_upolynomial_t* p, const lp_upolyno
     tracef("upolynomial_add("); lp_upolynomial_print(p, trace_out); tracef(", "); lp_upolynomial_print(q, trace_out); tracef(")\n");
   }
 
-  lp_int_ring_t* K = p->K;
+  const lp_int_ring_t* K = p->K;
 
   // Get the end degree
   size_t degree = lp_upolynomial_degree(p);
@@ -354,7 +354,7 @@ lp_upolynomial_t* lp_upolynomial_sub(const lp_upolynomial_t* p, const lp_upolyno
     tracef("upolynomial_sub("); lp_upolynomial_print(p, trace_out); tracef(", "); lp_upolynomial_print(q, trace_out); tracef(")\n");
   }
 
-  lp_int_ring_t* K = p->K;
+  const lp_int_ring_t* K = p->K;
 
   // Get the end degree
   size_t degree = lp_upolynomial_degree(p);
@@ -565,7 +565,7 @@ void lp_upolynomial_div_general(const lp_upolynomial_t* p, const lp_upolynomial_
   assert(p->K == q->K);
   assert(lp_upolynomial_degree(q) <= lp_upolynomial_degree(p));
 
-  lp_int_ring_t* K = p->K;
+  const lp_int_ring_t* K = p->K;
 
   int p_deg = lp_upolynomial_degree(p);
   int q_deg = lp_upolynomial_degree(q);
@@ -670,7 +670,7 @@ lp_upolynomial_t* lp_upolynomial_div_exact(const lp_upolynomial_t* p, const lp_u
   lp_upolynomial_t* result = 0;
 
   if (lp_upolynomial_degree(p) >= lp_upolynomial_degree(q)) {
-    lp_int_ring_t* K = p->K;
+    const lp_int_ring_t* K = p->K;
     upolynomial_dense_t rem_buffer;
     upolynomial_dense_t div_buffer;
     lp_upolynomial_div_general(p, q, &div_buffer, &rem_buffer, /** exact */ 1);
@@ -697,7 +697,7 @@ lp_upolynomial_t* lp_upolynomial_div_exact_c(const lp_upolynomial_t* p, const lp
     integer_print(c, trace_out); tracef(")\n");
   }
 
-  lp_int_ring_t* K = p->K;
+  const lp_int_ring_t* K = p->K;
 
   assert(p);
   assert(integer_cmp_int(K, c, 0));
@@ -736,7 +736,7 @@ lp_upolynomial_t* lp_upolynomial_rem_exact(const lp_upolynomial_t* p, const lp_u
   lp_upolynomial_t* result = 0;
 
   if (lp_upolynomial_degree(p) >= lp_upolynomial_degree(q)) {
-    lp_int_ring_t* K = p->K;
+    const lp_int_ring_t* K = p->K;
     upolynomial_dense_t rem_buffer;
     upolynomial_dense_t div_buffer;
     lp_upolynomial_div_general(p, q, &div_buffer, &rem_buffer, /** exact */ 1);
@@ -769,7 +769,7 @@ void lp_upolynomial_div_rem_exact(const lp_upolynomial_t* p, const lp_upolynomia
   assert(*div == 0 && *rem == 0);
 
   if (lp_upolynomial_degree(p) >= lp_upolynomial_degree(q)) {
-    lp_int_ring_t* K = p->K;
+    const lp_int_ring_t* K = p->K;
     upolynomial_dense_t rem_buffer;
     upolynomial_dense_t div_buffer;
     lp_upolynomial_div_general(p, q, &div_buffer, &rem_buffer, /** exact */ 1);
@@ -803,7 +803,7 @@ void lp_upolynomial_div_pseudo(lp_upolynomial_t** div, lp_upolynomial_t** rem, c
 
   assert(lp_upolynomial_degree(p) >= lp_upolynomial_degree(q));
 
-  lp_int_ring_t* K = p->K;
+  const lp_int_ring_t* K = p->K;
 
   upolynomial_dense_t rem_buffer;
   upolynomial_dense_t div_buffer;
@@ -834,7 +834,7 @@ int lp_upolynomial_divides(const lp_upolynomial_t* p, const lp_upolynomial_t* q)
     return 0;
   }
 
-  lp_int_ring_t* K = p->K;
+  const lp_int_ring_t* K = p->K;
 
   int result = 0;
 
@@ -946,7 +946,7 @@ lp_upolynomial_t* lp_upolynomial_primitive_part_Z(const lp_upolynomial_t* p) {
 }
 
 void lp_upolynomial_evaluate_at_integer(const lp_upolynomial_t* p, const lp_integer_t* x, lp_integer_t* value) {
-  lp_int_ring_t* K = p->K;
+  const lp_int_ring_t* K = p->K;
   lp_integer_t power;
   integer_construct_from_int(lp_Z, &power, 0);
 

--- a/src/upolynomial/upolynomial_dense.c
+++ b/src/upolynomial/upolynomial_dense.c
@@ -27,7 +27,7 @@
 #include <assert.h>
 
 static inline
-void upolynomial_dense_normalize(upolynomial_dense_t* p_d, lp_int_ring_t* K) {
+void upolynomial_dense_normalize(upolynomial_dense_t* p_d, const lp_int_ring_t* K) {
   int d = p_d->size - 1;
   while (d > 0 && integer_sgn(K, p_d->coefficients + d) == 0) {
     d --;
@@ -162,7 +162,7 @@ void upolynomial_dense_clear(upolynomial_dense_t* p_d) {
   p_d->size = 1;
 }
 
-lp_upolynomial_t* upolynomial_dense_to_upolynomial(const upolynomial_dense_t* p_d, lp_int_ring_t* K) {
+lp_upolynomial_t* upolynomial_dense_to_upolynomial(const upolynomial_dense_t* p_d, const lp_int_ring_t* K) {
   assert(p_d->size > 0);
   lp_upolynomial_t* result = lp_upolynomial_construct(K, p_d->size - 1, p_d->coefficients);
   return result;
@@ -219,7 +219,7 @@ void upolynomial_dense_mk_primitive_Z(upolynomial_dense_t* p_d, int positive) {
   integer_destruct(&gcd);
 }
 
-void upolynomial_dense_mult_c(upolynomial_dense_t* p_d, lp_int_ring_t* K, const lp_integer_t* c) {
+void upolynomial_dense_mult_c(upolynomial_dense_t* p_d, const lp_int_ring_t* K, const lp_integer_t* c) {
   assert(integer_sgn(K, c));
   lp_integer_t mult;
   integer_construct_from_int(lp_Z, &mult, 0);
@@ -233,7 +233,7 @@ void upolynomial_dense_mult_c(upolynomial_dense_t* p_d, lp_int_ring_t* K, const 
   integer_destruct(&mult);
 }
 
-void upolynomial_dense_div_c(upolynomial_dense_t* p_d, lp_int_ring_t* K, const lp_integer_t* c) {
+void upolynomial_dense_div_c(upolynomial_dense_t* p_d, const lp_int_ring_t* K, const lp_integer_t* c) {
   assert(integer_sgn(K, c));
   lp_integer_t div;
   integer_construct_from_int(lp_Z, &div, 0);
@@ -309,7 +309,7 @@ void upolynomial_dense_sub_mult_p_mon(upolynomial_dense_t* p_d, const lp_upolyno
   upolynomial_dense_normalize(p_d, p->K);
 }
 
-void upolynomial_dense_sub_mult_mon(upolynomial_dense_t* p_d, lp_int_ring_t* K, const upolynomial_dense_t* p, const ulp_monomial_t* m) {
+void upolynomial_dense_sub_mult_mon(upolynomial_dense_t* p_d, const lp_int_ring_t* K, const upolynomial_dense_t* p, const ulp_monomial_t* m) {
   assert(m->degree > 0 || integer_sgn(K, &m->coefficient));
 
   size_t needed_size = p->size + m->degree;
@@ -329,7 +329,7 @@ void upolynomial_dense_sub_mult_mon(upolynomial_dense_t* p_d, lp_int_ring_t* K, 
 }
 
 
-void upolynomial_dense_sub_mult(upolynomial_dense_t* p_d, lp_int_ring_t* K, const upolynomial_dense_t* p, const upolynomial_dense_t* q) {
+void upolynomial_dense_sub_mult(upolynomial_dense_t* p_d, const lp_int_ring_t* K, const upolynomial_dense_t* p, const upolynomial_dense_t* q) {
 
   if (upolynomial_dense_is_zero(p) || upolynomial_dense_is_zero(q)) {
     return;
@@ -357,14 +357,14 @@ void upolynomial_dense_sub_mult(upolynomial_dense_t* p_d, lp_int_ring_t* K, cons
   upolynomial_dense_normalize(p_d, K);
 }
 
-void upolynomial_dense_negate(upolynomial_dense_t* p_d, lp_int_ring_t* K) {
+void upolynomial_dense_negate(upolynomial_dense_t* p_d, const lp_int_ring_t* K) {
   size_t i;
   for (i = 0; i < p_d->size; ++ i) {
     integer_neg(K, p_d->coefficients + i, p_d->coefficients + i);
   }
 }
 
-void upolynomial_dense_div_general(lp_int_ring_t* K, int exact, const upolynomial_dense_t* p, const upolynomial_dense_t* q, upolynomial_dense_t* div, upolynomial_dense_t* rem) {
+void upolynomial_dense_div_general(const lp_int_ring_t* K, int exact, const upolynomial_dense_t* p, const upolynomial_dense_t* q, upolynomial_dense_t* div, upolynomial_dense_t* rem) {
 
   if (trace_is_enabled("division")) {
     tracef("upolynomial_div_general(");
@@ -545,7 +545,7 @@ void upolynomial_dense_reduce_Z(const upolynomial_dense_t* p, const upolynomial_
   TRACE("division", "upolynomial_dense_reduce_Z(): done\n");
 }
 
-void upolynomial_dense_derivative(lp_int_ring_t* K, const upolynomial_dense_t* p_d, upolynomial_dense_t* p_d_prime) {
+void upolynomial_dense_derivative(const lp_int_ring_t* K, const upolynomial_dense_t* p_d, upolynomial_dense_t* p_d_prime) {
   upolynomial_dense_clear(p_d_prime);
   int deg = p_d->size - 1;
   if (deg > 0) {

--- a/src/upolynomial/upolynomial_dense.h
+++ b/src/upolynomial/upolynomial_dense.h
@@ -122,7 +122,7 @@ int upolynomial_dense_sgn_at_minus_inf(const upolynomial_dense_t* p_d);
 /**
  * Returns the sparse polynomial.
  */
-lp_upolynomial_t* upolynomial_dense_to_upolynomial(const upolynomial_dense_t* p_d, lp_int_ring_t* K);
+lp_upolynomial_t* upolynomial_dense_to_upolynomial(const upolynomial_dense_t* p_d, const lp_int_ring_t* K);
 
 /**
  * Call when modifying a coefficient, so as to keep internal consistency.
@@ -138,12 +138,12 @@ void upolynomial_dense_mk_primitive_Z(upolynomial_dense_t* p_d, int positive);
 /**
  * p_d *= c
  */
-void upolynomial_dense_mult_c(upolynomial_dense_t* p_d, lp_int_ring_t* K, const lp_integer_t* c);
+void upolynomial_dense_mult_c(upolynomial_dense_t* p_d, const lp_int_ring_t* K, const lp_integer_t* c);
 
 /**
  * p_d /= c (c should should divide all coefficiants).
  */
-void upolynomial_dense_div_c(upolynomial_dense_t* p_d, lp_int_ring_t* K, const lp_integer_t* c);
+void upolynomial_dense_div_c(upolynomial_dense_t* p_d, const lp_int_ring_t* K, const lp_integer_t* c);
 
 /**
  * p_d += p*c
@@ -171,25 +171,25 @@ void upolynomial_dense_sub_mult_p_mon(upolynomial_dense_t* p_d, const lp_upolyno
 /**
  * p_d -= p*m
  */
-void upolynomial_dense_sub_mult_mon(upolynomial_dense_t* p_d, lp_int_ring_t* K,
+void upolynomial_dense_sub_mult_mon(upolynomial_dense_t* p_d, const lp_int_ring_t* K,
     const upolynomial_dense_t* p, const ulp_monomial_t* m);
 
 /**
  * p_d = -p_d
  */
-void upolynomial_dense_negate(upolynomial_dense_t* p_d, lp_int_ring_t* K);
+void upolynomial_dense_negate(upolynomial_dense_t* p_d, const lp_int_ring_t* K);
 
 /**
  * p_d -= p*q
  */
-void upolynomial_dense_sub_mult(upolynomial_dense_t* p_d, lp_int_ring_t* K,
+void upolynomial_dense_sub_mult(upolynomial_dense_t* p_d, const lp_int_ring_t* K,
     const upolynomial_dense_t* p, const upolynomial_dense_t* q);
 
 /**
  * General division p = div*q + rem in the ring K, if exact. If not exact, then
  * we compute lcm(q)^(p_deg - q_deg + 1) p = div*q + rem.
  */
-void upolynomial_dense_div_general(lp_int_ring_t* K, int exact, const upolynomial_dense_t* p,
+void upolynomial_dense_div_general(const lp_int_ring_t* K, int exact, const upolynomial_dense_t* p,
     const upolynomial_dense_t* q, upolynomial_dense_t* div,
     upolynomial_dense_t* rem);
 
@@ -203,5 +203,5 @@ void upolynomial_dense_reduce_Z(const upolynomial_dense_t* p_d, const upolynomia
 /**
  * Derivative.
  */
-void upolynomial_dense_derivative(lp_int_ring_t* K, const upolynomial_dense_t* p_d,
+void upolynomial_dense_derivative(const lp_int_ring_t* K, const upolynomial_dense_t* p_d,
     upolynomial_dense_t* p_d_prime);


### PR DESCRIPTION
PR #24 left some places untouched where `lp_int_ring_t*` was still used without `const`. This adds const to these remaining places, mostly concerning the univariate polynomial.