### PR TITLE
Adding wrapper classes for lp_integer_t and lp_rational_t

### DIFF
--- a/include/polyxx.h
+++ b/include/polyxx.h
@@ -3,4 +3,7 @@
 #include "poly.h"
 
 #include "polyxx/context.h"
+#include "polyxx/integer.h"
+#include "polyxx/integer_ring.h"
+#include "polyxx/rational.h"
 #include "polyxx/variable.h"

--- a/include/polyxx/integer.h
+++ b/include/polyxx/integer.h
@@ -1,0 +1,291 @@
+#pragma once
+
+#include <gmpxx.h>
+
+#include <iosfwd>
+
+#include "../integer.h"
+#include "integer_ring.h"
+
+namespace poly {
+
+  class Rational;
+
+  /**
+   * Implements a wrapper for lp_integer_t.
+   */
+  class Integer {
+    /** The actual integer. */
+    lp_integer_t mInt;
+
+   public:
+    /** Constructs zero. */
+    Integer();
+    /** Constructs from an int. */
+    explicit Integer(int i);
+    /** Constructs from a long. */
+    explicit Integer(long i);
+    /** Constructs from a long into the given ring. */
+    Integer(const IntegerRing& ir, long i);
+    /** Constructs from a string. */
+    Integer(const char* x, int base);
+    /** Constructs from a string into the given ring. */
+    Integer(const IntegerRing& ir, const char* x, int base);
+    /** Constructs as copy. */
+    Integer(const Integer& i);
+    /** Constructs as copy into the given ring. */
+    Integer(const IntegerRing& ir, const Integer& i);
+    /** Constructs as copy, assuming the rational is indeed an integer. */
+    explicit Integer(const Rational& r);
+    /** Constructs as copy, assuming the rational is indeed an integer, into the
+     * given ring. */
+    Integer(const IntegerRing& ir, const Rational& r);
+
+    /** Construct from a mpz_class, which is the underlying representation
+     * anyway. */
+    explicit Integer(const mpz_class& m);
+    /** Construct from a mpz_class, which is the underlying representation
+     * anyway, into the given ring. */
+    Integer(const IntegerRing& ir, const mpz_class& m);
+    /** Construct from an internal lp_integer_t pointer. */
+    explicit Integer(const lp_integer_t* i);
+    /** Construct from an internal lp_integer_t pointer into the given ring. */
+    Integer(const IntegerRing& ir, const lp_integer_t* i);
+
+    /** Custom destructor. */
+    ~Integer();
+    /** Assign from an Integer. */
+    Integer& operator=(const Integer& i);
+    /** Assign from an Integer into the given ring. */
+    Integer& assign(const IntegerRing& ir, const Integer& i);
+    /** Move from an Integer. */
+    Integer& operator=(Integer&& i);
+    /** Move from an Integer into the given ring. */
+    Integer& assign(const IntegerRing& ir, Integer&& i);
+    /** Assign from the given integer. */
+    Integer& operator=(long i);
+    /** Assign from the given integer into the given ring. */
+    Integer& assign(const IntegerRing& ir, long i);
+
+    /** Get a non-const pointer to the internal lp_integer_t. Handle with care!
+     */
+    lp_integer_t* get_internal();
+    /** Get a const pointer to the internal lp_integer_t. */
+    const lp_integer_t* get_internal() const;
+  };
+
+  /** Make sure that we can cast between Integer and lp_integer_t. */
+  static_assert(sizeof(Integer) == sizeof(lp_integer_t),
+                "Please check the size of Integer.");
+  namespace detail {
+    /** Non-const cast from an Integer to a lp_integer_t. */
+    inline lp_integer_t* cast_to(Integer* i) {
+      return reinterpret_cast<lp_integer_t*>(i);
+    }
+    /** Const cast from an Integer to a lp_integer_t. */
+    inline const lp_integer_t* cast_to(const Integer* i) {
+      return reinterpret_cast<const lp_integer_t*>(i);
+    }
+    /** Non-const cast from a lp_integer_t to an Integer. */
+    inline Integer* cast_from(lp_integer_t* i) {
+      return reinterpret_cast<Integer*>(i);
+    }
+    /** Const cast from a lp_integer_t to an Integer. */
+    inline const Integer* cast_from(const lp_integer_t* i) {
+      return reinterpret_cast<const Integer*>(i);
+    }
+  }  // namespace detail
+
+  /** Stream the given Integer to an output stream. */
+  std::ostream& operator<<(std::ostream& os, const Integer& i);
+
+  /** Number of bits needed for the given integer. */
+  std::size_t bit_size(const Integer& i);
+
+  /** Compare two integers. */
+  bool operator==(const Integer& lhs, const Integer& rhs);
+  /** Compare two integers. */
+  bool operator!=(const Integer& lhs, const Integer& rhs);
+  /** Compare two integers. */
+  bool operator<(const Integer& lhs, const Integer& rhs);
+  /** Compare two integers. */
+  bool operator<=(const Integer& lhs, const Integer& rhs);
+  /** Compare two integers. */
+  bool operator>(const Integer& lhs, const Integer& rhs);
+  /** Compare two integers. */
+  bool operator>=(const Integer& lhs, const Integer& rhs);
+
+  /** Compare two integers over the given ring. */
+  int compare(const IntegerRing& ir, const Integer& lhs, const Integer& rhs);
+  /** Compare two integers over the given ring. */
+  int compare(const IntegerRing& ir, const Integer& lhs, long rhs);
+  /** Compare two integers over the given ring. */
+  int compare(const IntegerRing& ir, long lhs, const Integer& rhs);
+
+  /** Checks whether lhs divides rhs. */
+  bool divides(const Integer& lhs, const Integer& rhs);
+  /** Checks whether lhs divides rhs over the given ring. */
+  bool divides(const IntegerRing& ir, const Integer& lhs, const Integer& rhs);
+
+  /** Swaps the contents of two integers. */
+  void swap(Integer& lhs, Integer& rhs);
+
+  /** Pre-increment an integer. */
+  Integer& operator++(Integer& i);
+  /** Pre-decrement an integer. */
+  Integer& operator--(Integer& i);
+  /** Post-increment an integer. */
+  Integer operator++(Integer& i, int);
+  /** Post-decrement an integer. */
+  Integer operator--(Integer& i, int);
+  /** Pre-increment an integer. */
+  Integer& increment(const IntegerRing& ir, Integer& i);
+  /** Pre-decrement an integer. */
+  Integer& decrement(const IntegerRing& ir, Integer& i);
+
+  /** Add two integers. */
+  Integer operator+(const Integer& lhs, const Integer& rhs);
+  /** Add and assign two integers. */
+  Integer& operator+=(Integer& lhs, const Integer& rhs);
+  /** Add two integers in the given ring. */
+  Integer add(const IntegerRing& ir, const Integer& lhs, const Integer& rhs);
+  /** Add and assign two integers in the given ring. */
+  Integer& add_assign(const IntegerRing& ir, Integer& lhs, const Integer& rhs);
+
+  /** Subtract two integers. */
+  Integer operator-(const Integer& lhs, const Integer& rhs);
+  /** Subtract and assign two integers. */
+  Integer& operator-=(Integer& lhs, const Integer& rhs);
+  /** Subtract two integers in the given ring. */
+  Integer sub(const IntegerRing& ir, const Integer& lhs, const Integer& rhs);
+  /** Subtract and assign two integers in the given ring. */
+  Integer& sub_assign(const IntegerRing& ir, Integer& lhs, const Integer& rhs);
+
+  /** Negate an integer. */
+  Integer operator-(const Integer& i);
+  /** Negate an integer in the given ring. */
+  Integer neg(const IntegerRing& ir, const Integer& i);
+
+  /** Compute the absolute value. */
+  Integer abs(const Integer& i);
+  /** Compute the absolute value in the given ring. */
+  Integer abs(const IntegerRing& ir, const Integer& i);
+
+  /** Compute the inverse in the given ring.
+   * Note that inverses do not exist in Z (except for -1 and 1).
+   */
+  Integer inverse(const IntegerRing& ir, const Integer& i);
+
+  /** Multiply two integers. */
+  Integer operator*(const Integer& lhs, const Integer& rhs);
+  /** Multiply two integers. */
+  Integer operator*(const Integer& lhs, long rhs);
+  /** Multiply two integers. */
+  Integer operator*(long lhs, const Integer& rhs);
+  /** Multiply and assign two integers. */
+  Integer& operator*=(Integer& lhs, const Integer& rhs);
+  /** Multiply and assign two integers. */
+  Integer& operator*=(Integer& lhs, long rhs);
+  /** Multiply two integers in the given ring. */
+  Integer mul(const IntegerRing& ir, const Integer& lhs, const Integer& rhs);
+  /** Multiply two integers in the given ring. */
+  Integer mul(const IntegerRing& ir, const Integer& lhs, long rhs);
+  /** Multiply two integers in the given ring. */
+  Integer mul(const IntegerRing& ir, long lhs, const Integer& rhs);
+  /** Multiply and assign two integers in the given ring. */
+  Integer& mul_assign(const IntegerRing& ir, Integer& lhs, const Integer& rhs);
+  /** Multiply and assign two integers in the given ring. */
+  Integer& mul_assign(const IntegerRing& ir, Integer& lhs, long rhs);
+
+  /** Compute lhs * 2^rhs. */
+  Integer mul_pow2(const Integer& lhs, unsigned rhs);
+  /** Compute lhs * 2^rhs in the given ring. */
+  Integer mul_pow2(const IntegerRing& ir, const Integer& lhs, unsigned rhs);
+
+  /** Compute lhs^rhs. */
+  Integer pow(const Integer& lhs, unsigned rhs);
+  /** Compute lhs^rhs in the given ring. */
+  Integer pow(const IntegerRing& ir, const Integer& lhs, unsigned rhs);
+
+  /** Compute the (truncated part of the) square root. */
+  Integer sqrt(const Integer& i);
+
+  /** Compute lhs += a * b. */
+  Integer& add_mul(Integer& lhs, const Integer& a, const Integer& b);
+  /** Compute lhs += a * b in the given ring. */
+  Integer& add_mul(const IntegerRing& ir, Integer& lhs, const Integer& a,
+                   const Integer& b);
+  /** Compute lhs += a * b. */
+  Integer& add_mul(Integer& lhs, const Integer& a, int b);
+  /** Compute lhs += a * b in the given ring. */
+  Integer& add_mul(const IntegerRing& ir, Integer& lhs, const Integer& a, int b);
+
+  /** Compute lhs -= a * b. */
+  Integer& sub_mul(Integer& lhs, const Integer& a, const Integer& b);
+  /** Compute lhs -= a * b in the given ring. */
+  Integer& sub_mul(const IntegerRing& ir, Integer& lhs, const Integer& a,
+                   const Integer& b);
+
+  /** Compute the (truncated part of the) quotient of two integers. */
+  Integer operator/(const Integer& lhs, const Integer& rhs);
+  /** Compute and assign the (truncated part of the) quotient of two integers.
+   */
+  Integer& operator/=(Integer& lhs, const Integer& rhs);
+
+  /** Compute the remainder of two integers. */
+  Integer operator%(const Integer& lhs, const Integer& rhs);
+  /** Compute and assign the remainder of two integers. */
+  Integer& operator%=(Integer& lhs, const Integer& rhs);
+
+  /** Compute the quotient of two integers, assuming that divides(lhs, rhs). */
+  Integer div_exact(const Integer& lhs, const Integer& rhs);
+  /** Compute the quotient of two integers in the given ring, assuming that
+   * divides(lhs, rhs). */
+  Integer div_exact(const IntegerRing& ir, const Integer& lhs, const Integer& rhs);
+
+  /** Compute the quotient and remainder of two integers. */
+  Integer div_rem(Integer& rem, const Integer& lhs, const Integer& rhs);
+
+  /** Compute the quotient and remainder of lhs and 2^rhs. */
+  Integer div_rem_pow2(Integer& rem, const Integer& lhs, unsigned rhs);
+
+  /** Returns the integer as a long. May get truncated, but keeps the correct
+   * sign. */
+  long to_int(const Integer& i);
+  /** Returns the integer as a double. */
+  double to_double(const Integer& i);
+
+  /** Checks whether the integer is a prime number.
+   * If the integer is negative, checks whether abs(i) is a prime number.
+   */
+  bool is_prime(const Integer& i);
+  /** Checks whether the integer is zero. */
+  bool is_zero(const Integer& i);
+  /** Checks whether the integer is zero in the given ring. */
+  bool is_zero(const IntegerRing& ir, const Integer& i);
+  /** Checks whether the integer is in the given ring. */
+  bool is_in_ring(const IntegerRing& ir, const Integer& i);
+
+  /** Computes the hash of an integer. */
+  std::size_t hash(const Integer& i);
+
+  /** Computes the sign of an integer. */
+  int sgn(const Integer& i);
+  /** Computes the sign of an integer in the given ring. */
+  int sgn(const IntegerRing& ir, const Integer& i);
+
+  /** Computes the greatest common divisor of two integers. */
+  Integer gcd(const Integer& a, const Integer& b);
+  /** Computes the least common multiple of two integers. */
+  Integer lcm(const Integer& a, const Integer& b);
+
+}  // namespace poly
+
+namespace std {
+  template <>
+  struct hash<poly::Integer> {
+    std::size_t operator()(const poly::Integer& i) const {
+      return poly::hash(i);
+    }
+  };
+}  // namespace std

--- a/include/polyxx/integer_ring.h
+++ b/include/polyxx/integer_ring.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "../integer.h"
+#include "utils.h"
+
+#include <iosfwd>
+
+namespace poly {
+
+  class Integer;
+
+  /** Represents an integer ring. Use IntegerRing::Z for the ring of all
+   * integers. */
+  class IntegerRing {
+    /** The actual ring. */
+    deleting_unique_ptr<lp_int_ring_t> mRing;
+
+    /** Construct the ring of all integers Z. */
+    IntegerRing();
+
+   public:
+    /** Construct the ring with the given modulus. */
+    IntegerRing(const Integer& m, bool is_prime);
+
+    /** Get a non-const pointer to the internal lp_int_ring_t. Handle with care!
+     */
+    lp_int_ring_t* get_internal();
+    /** Get a const pointer to the internal lp_int_ring_t. */
+    const lp_int_ring_t* get_internal() const;
+
+    /** The ring of all integers Z. */
+    static IntegerRing Z;
+  };
+
+  /** Compare two rings for equality. */
+  bool operator==(const IntegerRing& lhs, const IntegerRing& rhs);
+  /** Compare two rings for inequality. */
+  bool operator!=(const IntegerRing& lhs, const IntegerRing& rhs);
+
+  /** Stream the given IntegerRing to an output stream. */
+  std::ostream& operator<<(std::ostream& os, const IntegerRing& ir);
+
+}  // namespace poly

--- a/include/polyxx/rational.h
+++ b/include/polyxx/rational.h
@@ -18,7 +18,7 @@ namespace poly {
     /** Construct as zero. */
     Rational();
     /** Construct from an int. */
-    Rational(int i);
+    explicit Rational(int i);
     /** Copy from a rational. */
     Rational(const Rational& r);
     /** Move from a rational. */
@@ -29,9 +29,12 @@ namespace poly {
     /** Copy from numerator and denominator. */
     Rational(const Integer& num, const Integer& denom);
     /** Copy from Integer. */
-    Rational(const Integer& i);
+    explicit Rational(const Integer& i);
     /** Construct as d. */
-    Rational(double d);
+    explicit Rational(double d);
+    /** Construct from a mpq_class, which is the underlying representation
+     * anyway. */
+    explicit Rational(const mpq_class& m);
 
     /** Custom destructor. */
     ~Rational();

--- a/include/polyxx/rational.h
+++ b/include/polyxx/rational.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#include <iosfwd>
+
+#include "../rational.h"
+#include "integer.h"
+
+namespace poly {
+
+  /** Wrapper for a rational. */
+  class Rational {
+    /** Actual rational number. */
+    lp_rational_t mRat;
+
+   public:
+    /** Construct from an internal lp_rational_t pointer. */
+    explicit Rational(const lp_rational_t* r);
+    /** Construct as zero. */
+    Rational();
+    /** Construct from an int. */
+    Rational(int i);
+    /** Copy from a rational. */
+    Rational(const Rational& r);
+    /** Move from a rational. */
+    Rational(Rational&& r);
+
+    /** Copy from numerator and denominator. */
+    Rational(long num, unsigned long denom);
+    /** Copy from numerator and denominator. */
+    Rational(const Integer& num, const Integer& denom);
+    /** Copy from Integer. */
+    Rational(const Integer& i);
+    /** Construct as d. */
+    Rational(double d);
+
+    /** Custom destructor. */
+    ~Rational();
+
+    /** Copy from a rational. */
+    Rational& operator=(const Rational& r);
+    /** Move from a rational. */
+    Rational& operator=(Rational&& r);
+
+    /** Get a non-const pointer to the internal lp_rational_t. Handle with care!
+     */
+    lp_rational_t* get_internal();
+    /** Get a const pointer to the internal lp_rational_t. */
+    const lp_rational_t* get_internal() const;
+  };
+
+  /** Make sure that we can cast between Rational and lp_rational_t. */
+  static_assert(sizeof(Rational) == sizeof(lp_rational_t),
+                "Please check the size of Rational.");
+  namespace detail {
+    /** Non-const cast from a Rational to a lp_rational_t. */
+    inline lp_rational_t* cast_to(Rational* i) {
+      return reinterpret_cast<lp_rational_t*>(i);
+    }
+    /** Const cast from a Rational to a lp_rational_t. */
+    inline const lp_rational_t* cast_to(const Rational* i) {
+      return reinterpret_cast<const lp_rational_t*>(i);
+    }
+    /** Non-const cast from a lp_rational_t to a Rational. */
+    inline Rational* cast_from(lp_rational_t* i) {
+      return reinterpret_cast<Rational*>(i);
+    }
+    /** Const cast from a lp_rational_t to a Rational. */
+    inline const Rational* cast_from(const lp_rational_t* i) {
+      return reinterpret_cast<const Rational*>(i);
+    }
+  }  // namespace detail
+
+  /** Stream the given Rational to an output stream. */
+  std::ostream& operator<<(std::ostream& os, const Rational& r);
+
+  /** Give a double approximation. */
+  double to_double(const Rational& r);
+
+  /** Give the sign of a rational. */
+  int sgn(const Rational& r);
+
+  /** Compare two rational. */
+  bool operator==(const Rational& lhs, const Rational& rhs);
+  /** Compare two rational. */
+  bool operator!=(const Rational& lhs, const Rational& rhs);
+  /** Compare two rational. */
+  bool operator<(const Rational& lhs, const Rational& rhs);
+  /** Compare two rational. */
+  bool operator<=(const Rational& lhs, const Rational& rhs);
+  /** Compare two rational. */
+  bool operator>(const Rational& lhs, const Rational& rhs);
+  /** Compare two rational. */
+  bool operator>=(const Rational& lhs, const Rational& rhs);
+
+  /** Compare a rational and an integer. */
+  bool operator==(const Rational& lhs, const Integer& rhs);
+  /** Compare a rational and an integer. */
+  bool operator!=(const Rational& lhs, const Integer& rhs);
+  /** Compare a rational and an integer. */
+  bool operator<(const Rational& lhs, const Integer& rhs);
+  /** Compare a rational and an integer. */
+  bool operator<=(const Rational& lhs, const Integer& rhs);
+  /** Compare a rational and an integer. */
+  bool operator>(const Rational& lhs, const Integer& rhs);
+  /** Compare a rational and an integer. */
+  bool operator>=(const Rational& lhs, const Integer& rhs);
+
+  /** Compare an integer and a rational. */
+  bool operator==(const Integer& lhs, const Rational& rhs);
+  /** Compare an integer and a rational. */
+  bool operator!=(const Integer& lhs, const Rational& rhs);
+  /** Compare an integer and a rational. */
+  bool operator<(const Integer& lhs, const Rational& rhs);
+  /** Compare an integer and a rational. */
+  bool operator<=(const Integer& lhs, const Rational& rhs);
+  /** Compare an integer and a rational. */
+  bool operator>(const Integer& lhs, const Rational& rhs);
+  /** Compare an integer and a rational. */
+  bool operator>=(const Integer& lhs, const Rational& rhs);
+
+  /** Swap two rationals. */
+  void swap(Rational& lhs, Rational& rhs);
+
+  /** Add two rationals. */
+  Rational operator+(const Rational& lhs, const Rational& rhs);
+  /** Add a rational and an integer. */
+  Rational operator+(const Rational& lhs, const Integer& rhs);
+  /** Add an integer and a rational. */
+  Rational operator+(const Integer& lhs, const Rational& rhs);
+
+  /** Subtract two rationals. */
+  Rational operator-(const Rational& lhs, const Rational& rhs);
+  /** Negate a rational. */
+  Rational operator-(const Rational& r);
+
+  /** Invert a rational. */
+  Rational inverse(const Rational& r);
+
+  /** Multiply two rationals. */
+  Rational operator*(const Rational& lhs, const Rational& rhs);
+  /** Compute lhs * 2^n. */
+  Rational mul_2exp(const Rational& lhs, unsigned n);
+  /** Compute r^n. */
+  Rational pow(const Rational& r, unsigned n);
+
+  /** Divide two rationals. */
+  Rational operator/(const Rational& lhs, const Rational& rhs);
+  /** Compute lhs / 2^n. */
+  Rational div_2exp(const Rational& lhs, unsigned n);
+
+  /** Return the numerator of a rational. */
+  const Integer& numerator(const Rational& r);
+  /** Return the denominator of a rational. */
+  const Integer& denominator(const Rational& r);
+
+  /** Check if a rational is integral. */
+  bool is_integer(const Rational& r);
+
+  /** Compute the ceiling of a rational. */
+  Integer ceil(const Rational& r);
+  /** Compute the floor of a rational. */
+  Integer floor(const Rational& r);
+
+}  // namespace poly

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,9 @@ endif()
 
 set(polyxx_SOURCES
   polyxx/context.cpp
+  polyxx/integer_ring.cpp
+  polyxx/integer.cpp
+  polyxx/rational.cpp
   polyxx/variable.cpp
 )
 

--- a/src/polyxx/integer.cpp
+++ b/src/polyxx/integer.cpp
@@ -253,7 +253,7 @@ namespace poly {
   }
 
   Integer sqrt(const Integer& i) {
-    assert(i >= 0);
+    assert(i >= Integer());
     Integer res;
     lp_integer_sqrt_Z(res.get_internal(), i.get_internal());
     return res;

--- a/src/polyxx/integer.cpp
+++ b/src/polyxx/integer.cpp
@@ -1,0 +1,373 @@
+#include "polyxx/integer.h"
+
+#include <cassert>
+#include <iostream>
+#include <utility>
+
+#include "polyxx/rational.h"
+
+namespace poly {
+
+  Integer::Integer() { lp_integer_construct(&mInt); }
+
+  Integer::Integer(int i) : Integer(IntegerRing::Z, i) {}
+  Integer::Integer(long i) : Integer(IntegerRing::Z, i) {}
+  Integer::Integer(const IntegerRing& ir, long i) {
+    lp_integer_construct_from_int(ir.get_internal(), &mInt, i);
+  }
+
+  Integer::Integer(const char* x, int base)
+      : Integer(IntegerRing::Z, x, base) {}
+  Integer::Integer(const IntegerRing& ir, const char* x, int base) {
+    lp_integer_construct_from_string(ir.get_internal(), &mInt, x, base);
+  }
+
+  Integer::Integer(const Integer& i) : Integer(IntegerRing::Z, i) {}
+  Integer::Integer(const IntegerRing& ir, const Integer& i) {
+    lp_integer_construct_copy(ir.get_internal(), &mInt, i.get_internal());
+  }
+
+  Integer::Integer(const Rational& r) : Integer(IntegerRing::Z, r) {}
+  Integer::Integer(const IntegerRing& ir, const Rational& r) {
+    lp_integer_construct_from_rational(ir.get_internal(), &mInt,
+                                       r.get_internal());
+  }
+
+  Integer::Integer(const mpz_class& m) : Integer(IntegerRing::Z, m) {}
+  Integer::Integer(const IntegerRing& ir, const mpz_class& m) {
+    lp_integer_construct_copy(ir.get_internal(), &mInt, m.get_mpz_t());
+  }
+
+  Integer::Integer(const lp_integer_t* i) : Integer(IntegerRing::Z, i) {}
+  Integer::Integer(const IntegerRing& ir, const lp_integer_t* i) {
+    lp_integer_construct_copy(ir.get_internal(), &mInt, i);
+  }
+
+  Integer::~Integer() { lp_integer_destruct(&mInt); }
+
+  Integer& Integer::operator=(const Integer& i) {
+    return assign(IntegerRing::Z, i);
+  }
+  Integer& Integer::assign(const IntegerRing& ir, const Integer& i) {
+    lp_integer_assign(ir.get_internal(), &mInt, i.get_internal());
+    return *this;
+  }
+  Integer& Integer::operator=(Integer&& i) {
+    return assign(IntegerRing::Z, std::move(i));
+  }
+  Integer& Integer::assign(const IntegerRing& ir, Integer&& i) {
+    lp_integer_assign(ir.get_internal(), &mInt, i.get_internal());
+    return *this;
+  }
+  Integer& Integer::operator=(long i) { return assign(IntegerRing::Z, i); }
+  Integer& Integer::assign(const IntegerRing& ir, long i) {
+    lp_integer_assign_int(ir.get_internal(), &mInt, i);
+    return *this;
+  }
+
+  lp_integer_t* Integer::get_internal() { return &mInt; }
+
+  const lp_integer_t* Integer::get_internal() const { return &mInt; }
+
+  std::ostream& operator<<(std::ostream& os, const Integer& i) {
+    return os << lp_integer_to_string(i.get_internal());
+  }
+
+  std::size_t bit_size(const Integer& i) {
+    return lp_integer_bits(i.get_internal());
+  }
+
+  bool operator==(const Integer& lhs, const Integer& rhs) {
+    return compare(IntegerRing::Z, lhs, rhs) == 0;
+  }
+  bool operator!=(const Integer& lhs, const Integer& rhs) {
+    return compare(IntegerRing::Z, lhs, rhs) != 0;
+  }
+  bool operator<(const Integer& lhs, const Integer& rhs) {
+    return compare(IntegerRing::Z, lhs, rhs) < 0;
+  }
+  bool operator<=(const Integer& lhs, const Integer& rhs) {
+    return compare(IntegerRing::Z, lhs, rhs) <= 0;
+  }
+  bool operator>(const Integer& lhs, const Integer& rhs) {
+    return compare(IntegerRing::Z, lhs, rhs) > 0;
+  }
+  bool operator>=(const Integer& lhs, const Integer& rhs) {
+    return compare(IntegerRing::Z, lhs, rhs) >= 0;
+  }
+
+  int compare(const IntegerRing& ir, const Integer& lhs, const Integer& rhs) {
+    return lp_integer_cmp(ir.get_internal(), lhs.get_internal(),
+                          rhs.get_internal());
+  }
+  int compare(const IntegerRing& ir, const Integer& lhs, long rhs) {
+    return lp_integer_cmp_int(ir.get_internal(), lhs.get_internal(), rhs);
+  }
+  int compare(const IntegerRing& ir, long lhs, const Integer& rhs) {
+    return -lp_integer_cmp_int(ir.get_internal(), rhs.get_internal(), lhs);
+  }
+
+  bool divides(const Integer& lhs, const Integer& rhs) {
+    return divides(IntegerRing::Z, lhs, rhs);
+  }
+  bool divides(const IntegerRing& ir, const Integer& lhs, const Integer& rhs) {
+    return lp_integer_divides(ir.get_internal(), lhs.get_internal(),
+                              rhs.get_internal());
+  }
+
+  void swap(Integer& lhs, Integer& rhs) {
+    lp_integer_swap(lhs.get_internal(), rhs.get_internal());
+  }
+
+  Integer& operator++(Integer& i) { return increment(IntegerRing::Z, i); }
+  Integer& operator--(Integer& i) { return decrement(IntegerRing::Z, i); }
+  Integer operator++(Integer& i, int) {
+    Integer res(i);
+    ++i;
+    return res;
+  }
+  Integer operator--(Integer& i, int) {
+    Integer res(i);
+    --i;
+    return res;
+  }
+
+  Integer& increment(const IntegerRing& ir, Integer& i) {
+    lp_integer_inc(ir.get_internal(), i.get_internal());
+    return i;
+  }
+  Integer& decrement(const IntegerRing& ir, Integer& i) {
+    lp_integer_dec(ir.get_internal(), i.get_internal());
+    return i;
+  }
+
+  Integer operator+(const Integer& lhs, const Integer& rhs) {
+    return add(IntegerRing::Z, lhs, rhs);
+  }
+  Integer& operator+=(Integer& lhs, const Integer& rhs) {
+    return add_assign(IntegerRing::Z, lhs, rhs);
+  }
+  Integer add(const IntegerRing& ir, const Integer& lhs, const Integer& rhs) {
+    Integer res(lhs);
+    return add_assign(ir, res, rhs);
+  }
+  Integer& add_assign(const IntegerRing& ir, Integer& lhs, const Integer& rhs) {
+    lp_integer_add(ir.get_internal(), lhs.get_internal(), lhs.get_internal(),
+                   rhs.get_internal());
+    return lhs;
+  }
+
+  Integer operator-(const Integer& lhs, const Integer& rhs) {
+    return sub(IntegerRing::Z, lhs, rhs);
+  }
+  Integer& operator-=(Integer& lhs, const Integer& rhs) {
+    return sub_assign(IntegerRing::Z, lhs, rhs);
+  }
+  Integer sub(const IntegerRing& ir, const Integer& lhs, const Integer& rhs) {
+    Integer res(lhs);
+    return sub_assign(ir, res, rhs);
+  }
+
+  Integer& sub_assign(const IntegerRing& ir, Integer& lhs, const Integer& rhs) {
+    lp_integer_sub(ir.get_internal(), lhs.get_internal(), lhs.get_internal(),
+                   rhs.get_internal());
+    return lhs;
+  }
+
+  Integer operator-(const Integer& i) { return neg(IntegerRing::Z, i); }
+  Integer neg(const IntegerRing& ir, const Integer& i) {
+    Integer res;
+    lp_integer_neg(ir.get_internal(), res.get_internal(), i.get_internal());
+    return res;
+  }
+
+  Integer abs(const Integer& i) { return abs(IntegerRing::Z, i); }
+  Integer abs(const IntegerRing& ir, const Integer& i) {
+    Integer res;
+    lp_integer_abs(ir.get_internal(), res.get_internal(), i.get_internal());
+    return res;
+  }
+
+  Integer inverse(const IntegerRing& ir, const Integer& i) {
+    Integer res;
+    lp_integer_inv(ir.get_internal(), res.get_internal(), i.get_internal());
+    return res;
+  }
+
+  Integer operator*(const Integer& lhs, const Integer& rhs) {
+    return mul(IntegerRing::Z, lhs, rhs);
+  }
+  Integer operator*(const Integer& lhs, long rhs) {
+    return mul(IntegerRing::Z, lhs, rhs);
+  }
+  Integer operator*(long lhs, const Integer& rhs) {
+    return mul(IntegerRing::Z, lhs, rhs);
+  }
+  Integer& operator*=(Integer& lhs, const Integer& rhs) {
+    return mul_assign(IntegerRing::Z, lhs, rhs);
+  }
+  Integer& operator*=(Integer& lhs, long rhs) {
+    return mul_assign(IntegerRing::Z, lhs, rhs);
+  }
+
+  Integer mul(const IntegerRing& ir, const Integer& lhs, const Integer& rhs) {
+    Integer res(lhs);
+    return mul_assign(ir, res, rhs);
+  }
+  Integer mul(const IntegerRing& ir, const Integer& lhs, long rhs) {
+    Integer res(lhs);
+    return mul_assign(ir, res, rhs);
+  }
+  Integer mul(const IntegerRing& ir, long lhs, const Integer& rhs) {
+    return mul(ir, rhs, lhs);
+  }
+  Integer& mul_assign(const IntegerRing& ir, Integer& lhs, const Integer& rhs) {
+    lp_integer_mul(ir.get_internal(), lhs.get_internal(), lhs.get_internal(),
+                   rhs.get_internal());
+    return lhs;
+  }
+  Integer& mul_assign(const IntegerRing& ir, Integer& lhs, long rhs) {
+    lp_integer_mul_int(ir.get_internal(), lhs.get_internal(),
+                       lhs.get_internal(), rhs);
+    return lhs;
+  }
+
+  Integer mul_pow2(const Integer& lhs, unsigned rhs) {
+    return mul_pow2(IntegerRing::Z, lhs, rhs);
+  }
+  Integer mul_pow2(const IntegerRing& ir, const Integer& lhs, unsigned rhs) {
+    Integer res;
+    lp_integer_mul_pow2(ir.get_internal(), res.get_internal(),
+                        lhs.get_internal(), rhs);
+    return res;
+  }
+
+  Integer pow(const Integer& lhs, unsigned rhs) {
+    return pow(IntegerRing::Z, lhs, rhs);
+  }
+  Integer pow(const IntegerRing& ir, const Integer& lhs, unsigned rhs) {
+    Integer res;
+    lp_integer_pow(ir.get_internal(), res.get_internal(), lhs.get_internal(),
+                   rhs);
+    return res;
+  }
+
+  Integer sqrt(const Integer& i) {
+    assert(i >= 0);
+    Integer res;
+    lp_integer_sqrt_Z(res.get_internal(), i.get_internal());
+    return res;
+  }
+
+  Integer& add_mul(Integer& lhs, const Integer& a, const Integer& b) {
+    return add_mul(IntegerRing::Z, lhs, a, b);
+  }
+  Integer& add_mul(const IntegerRing& ir, Integer& lhs, const Integer& a,
+                   const Integer& b) {
+    lp_integer_add_mul(ir.get_internal(), lhs.get_internal(), a.get_internal(),
+                       b.get_internal());
+    return lhs;
+  }
+  Integer& add_mul(Integer& lhs, const Integer& a, int b) {
+    return add_mul(IntegerRing::Z, lhs, a, b);
+  }
+  Integer& add_mul(const IntegerRing& ir, Integer& lhs, const Integer& a, int b) {
+    lp_integer_add_mul_int(ir.get_internal(), lhs.get_internal(),
+                           a.get_internal(), b);
+    return lhs;
+  }
+
+  Integer& sub_mul(Integer& lhs, const Integer& a, const Integer& b) {
+    return sub_mul(IntegerRing::Z, lhs, a, b);
+  }
+  Integer& sub_mul(const IntegerRing& ir, Integer& lhs, const Integer& a,
+                   const Integer& b) {
+    lp_integer_sub_mul(ir.get_internal(), lhs.get_internal(), a.get_internal(),
+                       b.get_internal());
+    return lhs;
+  }
+
+  Integer operator/(const Integer& lhs, const Integer& rhs) {
+    Integer res(lhs);
+    return res /= rhs;
+  }
+  Integer& operator/=(Integer& lhs, const Integer& rhs) {
+    lp_integer_div_Z(lhs.get_internal(), lhs.get_internal(),
+                     rhs.get_internal());
+    return lhs;
+  }
+
+  Integer operator%(const Integer& lhs, const Integer& rhs) {
+    Integer res(lhs);
+    return res %= rhs;
+  }
+  Integer& operator%=(Integer& lhs, const Integer& rhs) {
+    lp_integer_rem_Z(lhs.get_internal(), lhs.get_internal(),
+                     rhs.get_internal());
+    return lhs;
+  }
+
+  Integer div_exact(const Integer& lhs, const Integer& rhs) {
+    return div_exact(IntegerRing::Z, lhs, rhs);
+  }
+  Integer div_exact(const IntegerRing& ir, const Integer& lhs, const Integer& rhs) {
+    Integer res;
+    lp_integer_div_exact(ir.get_internal(), res.get_internal(),
+                         lhs.get_internal(), rhs.get_internal());
+    return res;
+  }
+
+  Integer div_rem(Integer& rem, const Integer& lhs, const Integer& rhs) {
+    Integer res;
+    lp_integer_div_rem_Z(res.get_internal(), rem.get_internal(),
+                         lhs.get_internal(), rhs.get_internal());
+    return res;
+  }
+
+  Integer div_rem_pow2(Integer& rem, const Integer& lhs, unsigned rhs) {
+    Integer res;
+    lp_integer_div_rem_pow2_Z(res.get_internal(), rem.get_internal(),
+                              lhs.get_internal(), rhs);
+    return res;
+  }
+
+  long to_int(const Integer& i) { return lp_integer_to_int(i.get_internal()); }
+
+  double to_double(const Integer& i) {
+    return lp_integer_to_double(i.get_internal());
+  }
+
+  bool is_prime(const Integer& i) {
+    return lp_integer_is_prime(i.get_internal()) > 0;
+  }
+
+  bool is_zero(const Integer& i) { return is_zero(IntegerRing::Z, i); }
+  bool is_zero(const IntegerRing& ir, const Integer& i) {
+    return lp_integer_is_zero(ir.get_internal(), i.get_internal());
+  }
+
+  bool is_in_ring(const IntegerRing& ir, const Integer& i) {
+    return lp_integer_in_ring(ir.get_internal(), i.get_internal());
+  }
+
+  std::size_t hash(const Integer& i) {
+    return lp_integer_hash(i.get_internal());
+  }
+
+  int sgn(const Integer& i) { return sgn(IntegerRing::Z, i); }
+  int sgn(const IntegerRing& ir, const Integer& i) {
+    return lp_integer_sgn(ir.get_internal(), i.get_internal());
+  }
+
+  Integer gcd(const Integer& a, const Integer& b) {
+    Integer res;
+    lp_integer_gcd_Z(res.get_internal(), a.get_internal(), b.get_internal());
+    return res;
+  }
+  Integer lcm(const Integer& a, const Integer& b) {
+    Integer res;
+    lp_integer_lcm_Z(res.get_internal(), a.get_internal(), b.get_internal());
+    return res;
+  }
+
+}  // namespace poly

--- a/src/polyxx/integer_ring.cpp
+++ b/src/polyxx/integer_ring.cpp
@@ -1,0 +1,35 @@
+#include "polyxx/integer_ring.h"
+
+#include <iostream>
+#include <utility>
+
+#include "polyxx/integer.h"
+
+namespace poly {
+
+  IntegerRing IntegerRing::Z;
+
+  /** A deleter for an std::unique_ptr holding a lp_int_ring_t pointer */
+  void int_ring_deleter(lp_int_ring_t* ptr) { lp_int_ring_detach(ptr); }
+
+  IntegerRing::IntegerRing() : mRing(lp_Z, int_ring_deleter) {}
+
+  IntegerRing::IntegerRing(const Integer& m, bool is_prime)
+      : mRing(lp_int_ring_create(m.get_internal(), is_prime ? 1 : 0),
+              int_ring_deleter) {}
+
+  lp_int_ring_t* IntegerRing::get_internal() { return mRing.get(); }
+  const lp_int_ring_t* IntegerRing::get_internal() const { return mRing.get(); }
+
+  bool operator==(const IntegerRing& lhs, const IntegerRing& rhs) {
+    return lp_int_ring_equal(lhs.get_internal(), rhs.get_internal());
+  }
+  bool operator!=(const IntegerRing& lhs, const IntegerRing& rhs) {
+    return !(lhs == rhs);
+  }
+
+  std::ostream& operator<<(std::ostream& os, const IntegerRing& ir) {
+    return os << lp_int_ring_to_string(ir.get_internal());
+  }
+
+}  // namespace poly

--- a/src/polyxx/rational.cpp
+++ b/src/polyxx/rational.cpp
@@ -1,0 +1,192 @@
+#include "polyxx/rational.h"
+
+#include <iostream>
+
+namespace poly {
+
+  Rational::Rational() { lp_rational_construct(&mRat); }
+  Rational::Rational(int i) { lp_rational_construct_from_int(&mRat, i, 1); }
+
+  Rational::Rational(const Rational& r) {
+    lp_rational_construct_copy(&mRat, r.get_internal());
+  }
+  Rational::Rational(Rational&& r) {
+    lp_rational_construct_copy(&mRat, r.get_internal());
+  }
+
+  Rational::Rational(const Integer& num, const Integer& denom) {
+    lp_rational_construct_from_div(&mRat, num.get_internal(),
+                                   denom.get_internal());
+  }
+  Rational::Rational(long num, unsigned long denom) {
+    lp_rational_construct_from_int(&mRat, num, denom);
+  }
+  Rational::Rational(const Integer& i) {
+    lp_rational_construct_from_integer(&mRat, i.get_internal());
+  }
+  Rational::Rational(double d) { lp_rational_construct_from_double(&mRat, d); }
+
+  Rational::~Rational() { lp_rational_destruct(&mRat); }
+
+  Rational& Rational::operator=(const Rational& r) {
+    lp_rational_assign(&mRat, r.get_internal());
+    return *this;
+  }
+  Rational& Rational::operator=(Rational&& r) {
+    lp_rational_assign(&mRat, r.get_internal());
+    return *this;
+  }
+  lp_rational_t* Rational::get_internal() { return &mRat; }
+  const lp_rational_t* Rational::get_internal() const { return &mRat; }
+
+  std::ostream& operator<<(std::ostream& os, const Rational& r) {
+    return os << lp_rational_to_string(r.get_internal());
+  }
+
+  double to_double(const Rational& r) {
+    return lp_rational_to_double(r.get_internal());
+  }
+
+  int sgn(const Rational& r) { return lp_rational_sgn(r.get_internal()); }
+
+  bool operator==(const Rational& lhs, const Rational& rhs) {
+    return lp_rational_cmp(lhs.get_internal(), rhs.get_internal()) == 0;
+  }
+  bool operator!=(const Rational& lhs, const Rational& rhs) {
+    return lp_rational_cmp(lhs.get_internal(), rhs.get_internal()) != 0;
+  }
+  bool operator<(const Rational& lhs, const Rational& rhs) {
+    return lp_rational_cmp(lhs.get_internal(), rhs.get_internal()) < 0;
+  }
+  bool operator<=(const Rational& lhs, const Rational& rhs) {
+    return lp_rational_cmp(lhs.get_internal(), rhs.get_internal()) <= 0;
+  }
+  bool operator>(const Rational& lhs, const Rational& rhs) {
+    return lp_rational_cmp(lhs.get_internal(), rhs.get_internal()) > 0;
+  }
+  bool operator>=(const Rational& lhs, const Rational& rhs) {
+    return lp_rational_cmp(lhs.get_internal(), rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const Rational& lhs, const Integer& rhs) {
+    return lp_rational_cmp_integer(lhs.get_internal(), rhs.get_internal()) == 0;
+  }
+  bool operator!=(const Rational& lhs, const Integer& rhs) {
+    return lp_rational_cmp_integer(lhs.get_internal(), rhs.get_internal()) != 0;
+  }
+  bool operator<(const Rational& lhs, const Integer& rhs) {
+    return lp_rational_cmp_integer(lhs.get_internal(), rhs.get_internal()) < 0;
+  }
+  bool operator<=(const Rational& lhs, const Integer& rhs) {
+    return lp_rational_cmp_integer(lhs.get_internal(), rhs.get_internal()) <= 0;
+  }
+  bool operator>(const Rational& lhs, const Integer& rhs) {
+    return lp_rational_cmp_integer(lhs.get_internal(), rhs.get_internal()) > 0;
+  }
+  bool operator>=(const Rational& lhs, const Integer& rhs) {
+    return lp_rational_cmp_integer(lhs.get_internal(), rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const Integer& lhs, const Rational& rhs) {
+    return rhs == lhs;
+  }
+  bool operator!=(const Integer& lhs, const Rational& rhs) {
+    return rhs != lhs;
+  }
+  bool operator<(const Integer& lhs, const Rational& rhs) { return rhs > lhs; }
+  bool operator<=(const Integer& lhs, const Rational& rhs) {
+    return rhs >= lhs;
+  }
+  bool operator>(const Integer& lhs, const Rational& rhs) { return rhs < lhs; }
+  bool operator>=(const Integer& lhs, const Rational& rhs) {
+    return rhs <= lhs;
+  }
+
+  void swap(Rational& lhs, Rational& rhs) {
+    lp_rational_swap(lhs.get_internal(), rhs.get_internal());
+  }
+
+  Rational operator+(const Rational& lhs, const Rational& rhs) {
+    Rational res;
+    lp_rational_add(res.get_internal(), lhs.get_internal(), rhs.get_internal());
+    return res;
+  }
+  Rational operator+(const Rational& lhs, const Integer& rhs) {
+    Rational res;
+    lp_rational_add_integer(res.get_internal(), lhs.get_internal(),
+                            rhs.get_internal());
+    return res;
+  }
+  Rational operator+(const Integer& lhs, const Rational& rhs) {
+    return rhs + lhs;
+  }
+
+  Rational operator-(const Rational& lhs, const Rational& rhs) {
+    Rational res;
+    lp_rational_sub(res.get_internal(), lhs.get_internal(), rhs.get_internal());
+    return res;
+  }
+  Rational operator-(const Rational& r) {
+    Rational res;
+    lp_rational_neg(res.get_internal(), r.get_internal());
+    return res;
+  }
+  Rational inverse(const Rational& r) {
+    Rational res;
+    lp_rational_inv(res.get_internal(), r.get_internal());
+    return res;
+  }
+
+  Rational operator*(const Rational& lhs, const Rational& rhs) {
+    Rational res;
+    lp_rational_mul(res.get_internal(), lhs.get_internal(), rhs.get_internal());
+    return res;
+  }
+
+  Rational mul_2exp(const Rational& lhs, unsigned n) {
+    Rational res;
+    lp_rational_mul_2exp(res.get_internal(), lhs.get_internal(), n);
+    return res;
+  }
+
+  Rational pow(const Rational& r, unsigned n) {
+    Rational res;
+    lp_rational_pow(res.get_internal(), r.get_internal(), n);
+    return res;
+  }
+
+  Rational operator/(const Rational& lhs, const Rational& rhs) {
+    Rational res;
+    lp_rational_div(res.get_internal(), lhs.get_internal(), rhs.get_internal());
+    return res;
+  }
+
+  Rational div_2exp(const Rational& lhs, unsigned n) {
+    Rational res;
+    lp_rational_div_2exp(res.get_internal(), lhs.get_internal(), n);
+    return res;
+  }
+
+  const Integer& numerator(const Rational& r) {
+    return *detail::cast_from(mpq_numref(r.get_internal()));
+  }
+  const Integer& denominator(const Rational& r) {
+    return *detail::cast_from(mpq_denref(r.get_internal()));
+  }
+
+  bool is_integer(const Rational& r) {
+    return lp_rational_is_integer(r.get_internal());
+  }
+
+  Integer ceil(const Rational& r) {
+    Integer res;
+    lp_rational_ceiling(r.get_internal(), res.get_internal());
+    return res;
+  }
+  Integer floor(const Rational& r) {
+    Integer res;
+    lp_rational_floor(r.get_internal(), res.get_internal());
+    return res;
+  }
+
+}  // namespace poly

--- a/src/polyxx/rational.cpp
+++ b/src/polyxx/rational.cpp
@@ -26,6 +26,10 @@ namespace poly {
   }
   Rational::Rational(double d) { lp_rational_construct_from_double(&mRat, d); }
 
+  Rational::Rational(const mpq_class& m) {
+    lp_rational_construct_copy(get_internal(), m.get_mpq_t());
+  }
+
   Rational::~Rational() { lp_rational_destruct(&mRat); }
 
   Rational& Rational::operator=(const Rational& r) {

--- a/test/polyxx/CMakeLists.txt
+++ b/test/polyxx/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(polyxx_tests
+    test_integer
+    test_rational
     test_variable
 )
 

--- a/test/polyxx/test_integer.cpp
+++ b/test/polyxx/test_integer.cpp
@@ -1,0 +1,240 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include <polyxx.h>
+
+using namespace poly;
+
+TEST_CASE("integer::constructors") {
+    Integer i;
+    CHECK(i == Integer(0l));
+}
+
+TEST_CASE("integer::bit_size") {
+    CHECK(bit_size(Integer(5)) == 3);
+    CHECK(bit_size(Integer(64)) == 7);
+}
+
+TEST_CASE("integer::comparisons") {
+    CHECK(Integer(1) == Integer(1));
+    CHECK_FALSE(Integer(1) == Integer(2));
+    CHECK_FALSE(Integer(2) == Integer(1));
+
+    CHECK_FALSE(Integer(1) != Integer(1));
+    CHECK(Integer(1) != Integer(2));
+    CHECK(Integer(2) != Integer(1));
+
+    CHECK_FALSE(Integer(1) < Integer(1));
+    CHECK(Integer(1) < Integer(2));
+    CHECK_FALSE(Integer(2) < Integer(1));
+
+    CHECK(Integer(1) <= Integer(1));
+    CHECK(Integer(1) <= Integer(2));
+    CHECK_FALSE(Integer(2) <= Integer(1));
+
+    CHECK_FALSE(Integer(1) > Integer(1));
+    CHECK_FALSE(Integer(1) > Integer(2));
+    CHECK(Integer(2) > Integer(1));
+
+    CHECK(Integer(1) >= Integer(1));
+    CHECK_FALSE(Integer(1) >= Integer(2));
+    CHECK(Integer(2) >= Integer(1));
+}
+
+TEST_CASE("integer::divides") {
+    CHECK_FALSE(divides(Integer(15), Integer(5)));
+    CHECK(divides(Integer(5), Integer(15)));
+}
+
+TEST_CASE("integer::swap") {
+    Integer a(5);
+    Integer b(10);
+    swap(a, b);
+    CHECK(a == Integer(10));
+    CHECK(b == Integer(5));
+}
+
+TEST_CASE("integer::++") {
+    Integer a(5);
+    CHECK(++a == Integer(6));
+    CHECK(a == Integer(6));
+    CHECK(a++ == Integer(6));
+    CHECK(a == Integer(7));
+}
+
+TEST_CASE("integer::--") {
+    Integer a(5);
+    CHECK(--a == Integer(4));
+    CHECK(a == Integer(4));
+    CHECK(a-- == Integer(4));
+    CHECK(a == Integer(3));
+}
+
+TEST_CASE("integer::operator+") {
+    CHECK(Integer(3) + Integer(4) == Integer(7));
+    Integer a(3);
+    a += Integer(4);
+    CHECK(a == Integer(7));
+}
+
+TEST_CASE("integer::operator-") {
+    CHECK(Integer(3) - Integer(2) == Integer(1));
+    Integer a(3);
+    a -= Integer(2);
+    CHECK(a == Integer(1));
+    CHECK(-Integer(3) == Integer(-3));
+}
+
+TEST_CASE("integer::abs") {
+    CHECK(abs(Integer(-1)) == Integer(1));
+    CHECK(abs(Integer()) == Integer());
+    CHECK(abs(Integer(1)) == Integer(1));
+}
+
+TEST_CASE("integer::operator*") {
+    CHECK(Integer(3) * Integer(4) == Integer(12));
+    CHECK(Integer(3) * 4 == Integer(12));
+    CHECK(3 * Integer(4) == Integer(12));
+    Integer a(3);
+    a *= Integer(4);
+    CHECK(a == Integer(12));
+    a *= 4;
+    CHECK(a == Integer(48));
+}
+
+TEST_CASE("integer::mul_pow2") {
+    CHECK(mul_pow2(Integer(3), 0) == Integer(3));
+    CHECK(mul_pow2(Integer(3), 1) == Integer(6));
+    CHECK(mul_pow2(Integer(3), 2) == Integer(12));
+}
+
+TEST_CASE("integer::pow") {
+    CHECK(pow(Integer(3), 0) == Integer(1));
+    CHECK(pow(Integer(3), 1) == Integer(3));
+    CHECK(pow(Integer(3), 2) == Integer(9));
+}
+
+TEST_CASE("integer::sqrt") {
+    CHECK(sqrt(Integer(0)) == Integer(0));
+    CHECK(sqrt(Integer(1)) == Integer(1));
+    CHECK(sqrt(Integer(2)) == Integer(1));
+    CHECK(sqrt(Integer(3)) == Integer(1));
+    CHECK(sqrt(Integer(4)) == Integer(2));
+    CHECK(sqrt(Integer(15)) == Integer(3));
+    CHECK(sqrt(Integer(16)) == Integer(4));
+    CHECK(sqrt(Integer(17)) == Integer(4));
+}
+
+TEST_CASE("integer::add_mul") {
+    Integer a(3);
+    add_mul(a, Integer(2), Integer(3));
+    CHECK(a == Integer(9));
+    add_mul(a, Integer(2), 3);
+    CHECK(a == Integer(15));
+}
+
+TEST_CASE("integer::sub_mul") {
+    Integer a(20);
+    sub_mul(a, Integer(2), Integer(3));
+    CHECK(a == Integer(14));
+}
+
+TEST_CASE("integer::operator/") {
+    CHECK(Integer(13) / Integer(4) == Integer(3));
+    CHECK(Integer(12) / Integer(4) == Integer(3));
+    CHECK(Integer(11) / Integer(4) == Integer(2));
+}
+
+TEST_CASE("integer::operator/=") {
+    Integer a(20);
+    a /= Integer(5);
+    CHECK(a == Integer(4));
+    a /= Integer(3);
+    CHECK(a == Integer(1));
+}
+
+TEST_CASE("integer::operator%") {
+    CHECK(Integer(13) % Integer(4) == Integer(1));
+    CHECK(Integer(12) % Integer(4) == Integer(0));
+    CHECK(Integer(11) % Integer(4) == Integer(3));
+}
+
+TEST_CASE("integer::operator%=") {
+    Integer a(23);
+    a %= Integer(5);
+    CHECK(a == Integer(3));
+    a %= Integer(3);
+    CHECK(a == Integer(0));
+}
+
+TEST_CASE("integer::div_exact") {
+    CHECK(div_exact(Integer(16), Integer(4)) == Integer(4));
+    CHECK(div_exact(Integer(12), Integer(4)) == Integer(3));
+    CHECK(div_exact(Integer(8), Integer(4)) == Integer(2));
+}
+
+TEST_CASE("integer::div_exact") {
+    Integer rem;
+    CHECK(div_rem(rem, Integer(13), Integer(4)) == Integer(3));
+    CHECK(rem == Integer(1));
+    CHECK(div_rem(rem, Integer(12), Integer(4)) == Integer(3));
+    CHECK(rem == Integer(0));
+    CHECK(div_rem(rem, Integer(11), Integer(4)) == Integer(2));
+    CHECK(rem == Integer(3));
+}
+
+TEST_CASE("integer::div_exact") {
+    Integer rem;
+    CHECK(div_rem_pow2(rem, Integer(13), 2) == Integer(3));
+    CHECK(rem == Integer(1));
+    CHECK(div_rem_pow2(rem, Integer(12), 2) == Integer(3));
+    CHECK(rem == Integer(0));
+    CHECK(div_rem_pow2(rem, Integer(11), 2) == Integer(2));
+    CHECK(rem == Integer(3));
+}
+
+TEST_CASE("integer::to_int") {
+    CHECK(to_int(Integer(-10)) == -10);
+    CHECK(to_int(Integer()) == 0);
+    CHECK(to_int(Integer(5)) == 5);
+}
+
+TEST_CASE("integer::to_double") {
+    CHECK(to_double(Integer(-10)) == -10.0);
+    CHECK(to_double(Integer()) == 0.0);
+    CHECK(to_double(Integer(5)) == 5.0);
+}
+
+TEST_CASE("integer::is_prime") {
+    CHECK(is_prime(Integer(-3)));
+    CHECK(is_prime(Integer(-2)));
+    CHECK_FALSE(is_prime(Integer(-1)));
+    CHECK_FALSE(is_prime(Integer()));
+    CHECK_FALSE(is_prime(Integer(1)));
+    CHECK(is_prime(Integer(2)));
+    CHECK(is_prime(Integer(3)));
+    CHECK_FALSE(is_prime(Integer(4)));
+    CHECK(is_prime(Integer(5)));
+    CHECK_FALSE(is_prime(Integer(6)));
+    CHECK(is_prime(Integer(7)));
+}
+
+TEST_CASE("integer::is_zero") {
+    CHECK_FALSE(is_zero(Integer(-1)));
+    CHECK(is_zero(Integer()));
+    CHECK_FALSE(is_zero(Integer(3)));
+}
+
+TEST_CASE("integer::sgn") {
+    CHECK(sgn(Integer(-1)) == -1);
+    CHECK(sgn(Integer()) == 0);
+    CHECK(sgn(Integer(1)) == 1);
+}
+
+TEST_CASE("integer::gcd") {
+    CHECK(gcd(Integer(15), Integer(125)) == Integer(5));
+}
+
+TEST_CASE("integer::lcm") {
+    CHECK(lcm(Integer(15), Integer(35)) == Integer(105));
+}

--- a/test/polyxx/test_rational.cpp
+++ b/test/polyxx/test_rational.cpp
@@ -1,0 +1,165 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <polyxx.h>
+
+#include "doctest.h"
+
+using namespace poly;
+
+TEST_CASE("rational::constructors") {
+  CHECK(Rational() == Rational());
+  CHECK(Rational() == Rational(0, 1));
+  CHECK(Rational(13) == Rational(26, 2));
+  CHECK(Rational(Integer(7)) == Rational(21, 3));
+  CHECK(Rational(3.0) == Rational(6, 2));
+}
+
+TEST_CASE("rational::to_double") {
+  CHECK(to_double(Rational(1, 2)) == 0.5);
+  CHECK(to_double(Rational(1)) == 1.0);
+  CHECK(to_double(Rational(2)) == 2.0);
+}
+
+TEST_CASE("rational::sgn") {
+  CHECK(sgn(Rational(-10)) == -1);
+  CHECK(sgn(Rational(-1)) == -1);
+  CHECK(sgn(Rational()) == 0);
+  CHECK(sgn(Rational(1)) == 1);
+  CHECK(sgn(Rational(10)) == 1);
+}
+
+TEST_CASE("rational::operator==") {
+  CHECK_FALSE(Rational(1) == Rational(2));
+  CHECK_FALSE(Rational(1) == Integer(2));
+  CHECK_FALSE(Integer(1) == Rational(2));
+  CHECK(Rational(1) == Rational(1));
+  CHECK(Rational(1) == Integer(1));
+  CHECK(Integer(1) == Rational(1));
+  CHECK_FALSE(Rational(2) == Rational(1));
+  CHECK_FALSE(Rational(2) == Integer(1));
+  CHECK_FALSE(Integer(2) == Rational(1));
+}
+
+TEST_CASE("rational::operator!=") {
+  CHECK(Rational(1) != Rational(2));
+  CHECK(Rational(1) != Integer(2));
+  CHECK(Integer(1) != Rational(2));
+  CHECK_FALSE(Rational(1) != Rational(1));
+  CHECK_FALSE(Rational(1) != Integer(1));
+  CHECK_FALSE(Integer(1) != Rational(1));
+  CHECK(Rational(2) != Rational(1));
+  CHECK(Rational(2) != Integer(1));
+  CHECK(Integer(2) != Rational(1));
+}
+
+TEST_CASE("rational::operator<") {
+  CHECK(Rational(1) < Rational(2));
+  CHECK(Rational(1) < Integer(2));
+  CHECK(Integer(1) < Rational(2));
+  CHECK_FALSE(Rational(1) < Rational(1));
+  CHECK_FALSE(Rational(1) < Integer(1));
+  CHECK_FALSE(Integer(1) < Rational(1));
+  CHECK_FALSE(Rational(2) < Rational(1));
+  CHECK_FALSE(Rational(2) < Integer(1));
+  CHECK_FALSE(Integer(2) < Rational(1));
+}
+
+TEST_CASE("rational::operator<=") {
+  CHECK(Rational(1) <= Rational(2));
+  CHECK(Rational(1) <= Integer(2));
+  CHECK(Integer(1) <= Rational(2));
+  CHECK(Rational(1) <= Rational(1));
+  CHECK(Rational(1) <= Integer(1));
+  CHECK(Integer(1) <= Rational(1));
+  CHECK_FALSE(Rational(2) <= Rational(1));
+  CHECK_FALSE(Rational(2) <= Integer(1));
+  CHECK_FALSE(Integer(2) <= Rational(1));
+}
+
+TEST_CASE("rational::operator>") {
+  CHECK_FALSE(Rational(1) > Rational(2));
+  CHECK_FALSE(Rational(1) > Integer(2));
+  CHECK_FALSE(Integer(1) > Rational(2));
+  CHECK_FALSE(Rational(1) > Rational(1));
+  CHECK_FALSE(Rational(1) > Integer(1));
+  CHECK_FALSE(Integer(1) > Rational(1));
+  CHECK(Rational(2) > Rational(1));
+  CHECK(Rational(2) > Integer(1));
+  CHECK(Integer(2) > Rational(1));
+}
+
+TEST_CASE("rational::operator>=") {
+  CHECK_FALSE(Rational(1) >= Rational(2));
+  CHECK_FALSE(Rational(1) >= Integer(2));
+  CHECK_FALSE(Integer(1) >= Rational(2));
+  CHECK(Rational(1) >= Rational(1));
+  CHECK(Rational(1) >= Integer(1));
+  CHECK(Integer(1) >= Rational(1));
+  CHECK(Rational(2) >= Rational(1));
+  CHECK(Rational(2) >= Integer(1));
+  CHECK(Integer(2) >= Rational(1));
+}
+
+TEST_CASE("rational::swap") {
+  Rational a(1);
+  Rational b(2);
+  swap(a, b);
+  CHECK(a == Rational(2));
+  CHECK(b == Rational(1));
+}
+
+TEST_CASE("rational::operator+") {
+  CHECK(Rational(1) + Rational(2) == Rational(3));
+  CHECK(Rational(1) + Integer(2) == Rational(3));
+  CHECK(Integer(1) + Rational(2) == Rational(3));
+}
+TEST_CASE("rational::operator-") {
+  CHECK(Rational(1) - Rational(2) == Rational(-1));
+  CHECK(-Rational(1) == Rational(-1));
+}
+
+TEST_CASE("rational::inverse") {
+  CHECK(inverse(Rational(1)) == Rational(1));
+  CHECK(inverse(Rational(Integer(1), Integer(2))) == Rational(2));
+  CHECK(inverse(Rational(2)) == Rational(Integer(1), Integer(2)));
+}
+TEST_CASE("rational::operator*") {
+  CHECK(Rational(1) * Rational(2) == Rational(2));
+}
+TEST_CASE("rational::mul_2exp") {
+  CHECK(mul_2exp(Rational(2), 2) == Rational(8));
+}
+TEST_CASE("rational::pow") { CHECK(pow(Rational(2), 3) == Rational(8)); }
+TEST_CASE("rational::operator/") {
+  CHECK(Rational(1) / Rational(1) == Rational(1));
+  CHECK(Rational(1) / Rational(2) == Rational(Integer(1), Integer(2)));
+}
+
+TEST_CASE("rational::div_2exp") {
+  CHECK(div_2exp(Rational(2), 2) == Rational(Integer(1), Integer(2)));
+}
+
+TEST_CASE("rational::numerator") {
+  CHECK(numerator(Rational(1)) == Rational(1));
+  CHECK(numerator(Rational(Integer(1), Integer(2))) == Rational(1));
+  CHECK(numerator(Rational(2)) == Rational(2));
+}
+TEST_CASE("rational::denominator") {
+  CHECK(denominator(Rational(1)) == Rational(1));
+  CHECK(denominator(Rational(Integer(1), Integer(2))) == Rational(2));
+  CHECK(denominator(Rational(2)) == Rational(1));
+}
+
+TEST_CASE("rational::is_integer") {
+  CHECK(is_integer(Rational(1)));
+  CHECK_FALSE(is_integer(Rational(Integer(1), Integer(2))));
+  CHECK(is_integer(Rational(2)));
+}
+
+TEST_CASE("rational::ceil") {
+  CHECK(ceil(Rational(1)) == Rational(1));
+  CHECK(ceil(Rational(Integer(1), Integer(2))) == Rational(1));
+}
+TEST_CASE("rational::floor") {
+  CHECK(floor(Rational(1)) == Rational(1));
+  CHECK(floor(Rational(Integer(1), Integer(2))) == Rational());
+}


### PR DESCRIPTION
Based on #25 , this PR adds new wrapper classes for `lp_integer_t` (`Integer`) and `lp_rational_t` (`Rational`). Additionally, a helper class `IntegerRing`(wrapping `lp_int_ring_t`) is added.
For `Integer`, usage with and without a custom integer ring, should be reasonably comfortable and straight forward. Both classes induce no memory overhead, which allows for easy (and fast) conversions of arrays by a simple cast.
Most of the C interface is exported in the C++ interface as well and unit tests are added.