### PR TITLE
Adding wrapper classes for lp_dyadic_rational_t and lp_dyadic_interval_t.

### DIFF
--- a/include/polyxx.h
+++ b/include/polyxx.h
@@ -3,4 +3,9 @@
 #include "poly.h"
 
 #include "polyxx/context.h"
+#include "polyxx/dyadic_interval.h"
+#include "polyxx/dyadic_rational.h"
+#include "polyxx/integer.h"
+#include "polyxx/integer_ring.h"
+#include "polyxx/rational.h"
 #include "polyxx/variable.h"

--- a/include/polyxx/dyadic_interval.h
+++ b/include/polyxx/dyadic_interval.h
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <iosfwd>
+
+#include "../dyadic_interval.h"
+#include "dyadic_rational.h"
+#include "integer.h"
+
+namespace poly {
+
+  /**
+   * Implements a wrapper for lp_dyadic_interval_t from libpoly.
+   */
+  class DyadicInterval {
+   private:
+    /** The actual interval. */
+    lp_dyadic_interval_t mInterval;
+
+   public:
+    /** Construct from an internal lp_dyadic_interval_t pointer. */
+    explicit DyadicInterval(const lp_dyadic_interval_t* di);
+    /** Construct a zero interval [0;0]. */
+    DyadicInterval();
+    /** Construct a point interval. */
+    DyadicInterval(const DyadicRational& dr);
+    /** Construct an open interval. */
+    DyadicInterval(const DyadicRational& a, const DyadicRational& b);
+    /** Construct an interval from the given bounds. */
+    DyadicInterval(const DyadicRational& a, bool a_open,
+                   const DyadicRational& b, bool b_open);
+    /** Construct a point interval. */
+    DyadicInterval(const Integer& i);
+    /** Construct an open interval. */
+    DyadicInterval(const Integer& a, const Integer& b);
+    /** Construct an interval from the given bounds. */
+    DyadicInterval(const Integer& a, bool a_open, const Integer& b,
+                   bool b_open);
+    /** Construct an open interval. */
+    DyadicInterval(long a, long b);
+    /** Construct an interval from the given bounds. */
+    DyadicInterval(long a, bool a_open, long b, bool b_open);
+    /** Copy from a DyadicInterval. */
+    DyadicInterval(const DyadicInterval& i);
+    /** Move from a DyadicInterval. */
+    DyadicInterval(DyadicInterval&& i);
+    /** Custom destructor. */
+    ~DyadicInterval();
+    /** Copy from a DyadicInterval. */
+    DyadicInterval& operator=(const DyadicInterval& i);
+    /** Move from a DyadicInterval. */
+    DyadicInterval& operator=(DyadicInterval&& i);
+
+    /** Get a non-const pointer to the internal lp_dyadic_interval_t. Handle
+     * with care! */
+    lp_dyadic_interval_t* get_internal();
+    /** Get a const pointer to the internal lp_dyadic_interval_t. */
+    const lp_dyadic_interval_t* get_internal() const;
+
+    /** Collapse this interval to a single point. */
+    void collapse(const DyadicRational& dr);
+    /** The the lower bound. */
+    void set_lower(const DyadicRational& dr, bool open);
+    /** The the upper bound. */
+    void set_upper(const DyadicRational& dr, bool open);
+    /** The this interval by 2^n. */
+    void scale(int n);
+  };
+
+  /** Stream the given DyadicInterval to an output stream. */
+  std::ostream& operator<<(std::ostream& os, const DyadicInterval& i);
+
+  /** Split the given interval. */
+  std::pair<DyadicInterval, DyadicInterval> split(const DyadicInterval& di,
+                                                  bool left_open,
+                                                  bool right_open);
+
+  /** Swap two intervals. */
+  void swap(DyadicInterval& lhs, DyadicInterval& rhs);
+
+  /** Compare two intervals. */
+  bool operator==(const DyadicInterval& lhs, const DyadicInterval& rhs);
+  /** Compare two intervals. */
+  bool operator!=(const DyadicInterval& lhs, const DyadicInterval& rhs);
+
+  /** Check whether the interval contains a given point. */
+  bool contains(const DyadicInterval& lhs, const DyadicRational& rhs);
+  /** Check whether the interval contains zero. */
+  bool contains_zero(const DyadicInterval& lhs);
+
+  /** Check whether two intervals are disjoint. */
+  bool disjoint(const DyadicInterval& lhs, const DyadicInterval& rhs);
+
+  /** Check whether an interval is a point. */
+  bool is_point(const DyadicInterval& di);
+  /** Get the point from a point interval. */
+  DyadicRational get_point(const DyadicInterval& di);
+  /** Get the lower bound. */
+  const DyadicRational& get_lower(const DyadicInterval& i);
+  /** Get the upper bound. */
+  const DyadicRational& get_upper(const DyadicInterval& i);
+
+  /** Get approximate log size. */
+  int log_size(const DyadicInterval& di);
+
+  /** Get sign of the interval. */
+  int sgn(const DyadicInterval& di);
+
+  /** Compare an interval and an integer. */
+  bool operator==(const DyadicInterval& lhs, const Integer& rhs);
+  /** Compare an interval and an integer. */
+  bool operator!=(const DyadicInterval& lhs, const Integer& rhs);
+  /** Compare an interval and an integer. */
+  bool operator<(const DyadicInterval& lhs, const Integer& rhs);
+  /** Compare an interval and an integer. */
+  bool operator<=(const DyadicInterval& lhs, const Integer& rhs);
+  /** Compare an interval and an integer. */
+  bool operator>(const DyadicInterval& lhs, const Integer& rhs);
+  /** Compare an interval and an integer. */
+  bool operator>=(const DyadicInterval& lhs, const Integer& rhs);
+
+  /** Compare an integer and an interval. */
+  bool operator==(const Integer& lhs, const DyadicInterval& rhs);
+  /** Compare an integer and an interval. */
+  bool operator!=(const Integer& lhs, const DyadicInterval& rhs);
+  /** Compare an integer and an interval. */
+  bool operator<(const Integer& lhs, const DyadicInterval& rhs);
+  /** Compare an integer and an interval. */
+  bool operator<=(const Integer& lhs, const DyadicInterval& rhs);
+  /** Compare an integer and an interval. */
+  bool operator>(const Integer& lhs, const DyadicInterval& rhs);
+  /** Compare an integer and an interval. */
+  bool operator>=(const Integer& lhs, const DyadicInterval& rhs);
+
+  /** Compare an interval and a rational. */
+  bool operator==(const DyadicInterval& lhs, const DyadicRational& rhs);
+  /** Compare an interval and a rational. */
+  bool operator!=(const DyadicInterval& lhs, const DyadicRational& rhs);
+  /** Compare an interval and a rational. */
+  bool operator<(const DyadicInterval& lhs, const DyadicRational& rhs);
+  /** Compare an interval and a rational. */
+  bool operator<=(const DyadicInterval& lhs, const DyadicRational& rhs);
+  /** Compare an interval and a rational. */
+  bool operator>(const DyadicInterval& lhs, const DyadicRational& rhs);
+  /** Compare an interval and a rational. */
+  bool operator>=(const DyadicInterval& lhs, const DyadicRational& rhs);
+
+  /** Compare a rational and an interval. */
+  bool operator==(const DyadicRational& lhs, const DyadicInterval& rhs);
+  /** Compare a rational and an interval. */
+  bool operator!=(const DyadicRational& lhs, const DyadicInterval& rhs);
+  /** Compare a rational and an interval. */
+  bool operator<(const DyadicRational& lhs, const DyadicInterval& rhs);
+  /** Compare a rational and an interval. */
+  bool operator<=(const DyadicRational& lhs, const DyadicInterval& rhs);
+  /** Compare a rational and an interval. */
+  bool operator>(const DyadicRational& lhs, const DyadicInterval& rhs);
+  /** Compare a rational and an interval. */
+  bool operator>=(const DyadicRational& lhs, const DyadicInterval& rhs);
+
+  /** Compare an interval and a rational. */
+  bool operator==(const DyadicInterval& lhs, const Rational& rhs);
+  /** Compare an interval and a rational. */
+  bool operator!=(const DyadicInterval& lhs, const Rational& rhs);
+  /** Compare an interval and a rational. */
+  bool operator<(const DyadicInterval& lhs, const Rational& rhs);
+  /** Compare an interval and a rational. */
+  bool operator<=(const DyadicInterval& lhs, const Rational& rhs);
+  /** Compare an interval and a rational. */
+  bool operator>(const DyadicInterval& lhs, const Rational& rhs);
+  /** Compare an interval and a rational. */
+  bool operator>=(const DyadicInterval& lhs, const Rational& rhs);
+
+  /** Compare a rational and an interval. */
+  bool operator==(const Rational& lhs, const DyadicInterval& rhs);
+  /** Compare a rational and an interval. */
+  bool operator!=(const Rational& lhs, const DyadicInterval& rhs);
+  /** Compare a rational and an interval. */
+  bool operator<(const Rational& lhs, const DyadicInterval& rhs);
+  /** Compare a rational and an interval. */
+  bool operator<=(const Rational& lhs, const DyadicInterval& rhs);
+  /** Compare a rational and an interval. */
+  bool operator>(const Rational& lhs, const DyadicInterval& rhs);
+  /** Compare a rational and an interval. */
+  bool operator>=(const Rational& lhs, const DyadicInterval& rhs);
+
+}  // namespace poly

--- a/include/polyxx/dyadic_interval.h
+++ b/include/polyxx/dyadic_interval.h
@@ -66,6 +66,29 @@ namespace poly {
     void scale(int n);
   };
 
+  /** Make sure that we can cast between DyadicInterval and
+   * lp_dyadic_interval_t. */
+  static_assert(sizeof(DyadicInterval) == sizeof(lp_dyadic_interval_t),
+                "Please check the size of DyadicInterval.");
+  namespace detail {
+    /** Non-const cast from an DyadicInterval to a lp_dyadic_interval_t. */
+    inline lp_dyadic_interval_t* cast_to(DyadicInterval* i) {
+      return reinterpret_cast<lp_dyadic_interval_t*>(i);
+    }
+    /** Const cast from an DyadicInterval to a lp_dyadic_interval_t. */
+    inline const lp_dyadic_interval_t* cast_to(const DyadicInterval* i) {
+      return reinterpret_cast<const lp_dyadic_interval_t*>(i);
+    }
+    /** Non-const cast from a lp_dyadic_interval_t to an DyadicInterval. */
+    inline DyadicInterval* cast_from(lp_dyadic_interval_t* i) {
+      return reinterpret_cast<DyadicInterval*>(i);
+    }
+    /** Const cast from a lp_dyadic_interval_t to an DyadicInterval. */
+    inline const DyadicInterval* cast_from(const lp_dyadic_interval_t* i) {
+      return reinterpret_cast<const DyadicInterval*>(i);
+    }
+  }  // namespace detail
+
   /** Stream the given DyadicInterval to an output stream. */
   std::ostream& operator<<(std::ostream& os, const DyadicInterval& i);
 

--- a/include/polyxx/dyadic_rational.h
+++ b/include/polyxx/dyadic_rational.h
@@ -1,0 +1,194 @@
+#pragma once
+
+#include <iosfwd>
+
+#include "../dyadic_rational.h"
+#include "integer.h"
+#include "rational.h"
+
+namespace poly {
+
+  /**
+   * Implements a dyadic rational, wrapping lp_dyadic_rational_t.
+   */
+  class DyadicRational {
+    /** The actual number. */
+    lp_dyadic_rational_t mDRat;
+
+   public:
+    /** Construct as zero. */
+    DyadicRational();
+    /** Copy from a DyadicRational. */
+    DyadicRational(const DyadicRational& dr);
+    /** Move from a DyadicRational. */
+    DyadicRational(DyadicRational&& dr);
+
+    /** Construct as a / 2^n. */
+    DyadicRational(long a, unsigned long n);
+    /** Construct from an Integer. */
+    explicit DyadicRational(const Integer& i);
+    /** Construct from a double. */
+    explicit DyadicRational(double d);
+    /** Construct from an int. */
+    DyadicRational(int i);
+
+    /** Construct from an internal lp_dyadic_rational_t pointer. */
+    explicit DyadicRational(const lp_dyadic_rational_t* dr);
+
+    /** Custom destructor. */
+    ~DyadicRational();
+
+    /** Copy from a dr. */
+    DyadicRational& operator=(const DyadicRational& dr);
+    /** Move from a DyadicRational. */
+    DyadicRational& operator=(DyadicRational&& dr);
+
+    /** Cast to a regular Rational. */
+    operator Rational() const;
+
+    /** Get a non-const pointer to the internal lp_dyadic_rational_t. Handle
+     * with care! */
+    lp_dyadic_rational_t* get_internal();
+    /** Get a const pointer to the internal lp_dyadic_rational_t. */
+    const lp_dyadic_rational_t* get_internal() const;
+  };
+
+  /** Make sure that we can cast between DyadicRational and
+   * lp_dyadic_rational_t. */
+  static_assert(sizeof(DyadicRational) == sizeof(lp_dyadic_rational_t),
+                "Please check the size of DyadicRational.");
+  namespace detail {
+    /** Non-const cast from an DyadicRational to a lp_dyadic_rational_t. */
+    inline lp_dyadic_rational_t* cast_to(DyadicRational* i) {
+      return reinterpret_cast<lp_dyadic_rational_t*>(i);
+    }
+    /** Const cast from an DyadicRational to a lp_dyadic_rational_t. */
+    inline const lp_dyadic_rational_t* cast_to(const DyadicRational* i) {
+      return reinterpret_cast<const lp_dyadic_rational_t*>(i);
+    }
+    /** Non-const cast from a lp_dyadic_rational_t to an DyadicRational. */
+    inline DyadicRational* cast_from(lp_dyadic_rational_t* i) {
+      return reinterpret_cast<DyadicRational*>(i);
+    }
+    /** Const cast from a lp_dyadic_rational_t to an DyadicRational. */
+    inline const DyadicRational* cast_from(const lp_dyadic_rational_t* i) {
+      return reinterpret_cast<const DyadicRational*>(i);
+    }
+  }  // namespace detail
+
+  /** Stream the given DyadicRational to an output stream. */
+  std::ostream& operator<<(std::ostream& os, const DyadicRational& dr);
+
+  /** Get a double representation of a DyadicRational. */
+  double to_double(const DyadicRational& dr);
+
+  /** Get the sign of a DyadicRational. */
+  int sgn(const DyadicRational& dr);
+
+  /** Compare two DyadicRationals. */
+  bool operator==(const DyadicRational& lhs, const DyadicRational& rhs);
+  /** Compare two DyadicRationals. */
+  bool operator!=(const DyadicRational& lhs, const DyadicRational& rhs);
+  /** Compare two DyadicRationals. */
+  bool operator<(const DyadicRational& lhs, const DyadicRational& rhs);
+  /** Compare two DyadicRationals. */
+  bool operator<=(const DyadicRational& lhs, const DyadicRational& rhs);
+  /** Compare two DyadicRationals. */
+  bool operator>(const DyadicRational& lhs, const DyadicRational& rhs);
+  /** Compare two DyadicRationals. */
+  bool operator>=(const DyadicRational& lhs, const DyadicRational& rhs);
+
+  /** Compare a DyadicRational with an Integer. */
+  bool operator==(const DyadicRational& lhs, const Integer& rhs);
+  /** Compare a DyadicRational with an Integer. */
+  bool operator!=(const DyadicRational& lhs, const Integer& rhs);
+  /** Compare a DyadicRational with an Integer. */
+  bool operator<(const DyadicRational& lhs, const Integer& rhs);
+  /** Compare a DyadicRational with an Integer. */
+  bool operator<=(const DyadicRational& lhs, const Integer& rhs);
+  /** Compare a DyadicRational with an Integer. */
+  bool operator>(const DyadicRational& lhs, const Integer& rhs);
+  /** Compare a DyadicRational with an Integer. */
+  bool operator>=(const DyadicRational& lhs, const Integer& rhs);
+
+  /** Compare an Integer with a DyadicRational. */
+  bool operator==(const Integer& lhs, const DyadicRational& rhs);
+  /** Compare an Integer with a DyadicRational. */
+  bool operator!=(const Integer& lhs, const DyadicRational& rhs);
+  /** Compare an Integer with a DyadicRational. */
+  bool operator<(const Integer& lhs, const DyadicRational& rhs);
+  /** Compare an Integer with a DyadicRational. */
+  bool operator<=(const Integer& lhs, const DyadicRational& rhs);
+  /** Compare an Integer with a DyadicRational. */
+  bool operator>(const Integer& lhs, const DyadicRational& rhs);
+  /** Compare an Integer with a DyadicRational. */
+  bool operator>=(const Integer& lhs, const DyadicRational& rhs);
+
+  /** Compare a DyadicRational with a Rational. */
+  bool operator==(const DyadicRational& lhs, const Rational& rhs);
+  /** Compare a DyadicRational with a Rational. */
+  bool operator!=(const DyadicRational& lhs, const Rational& rhs);
+  /** Compare a DyadicRational with a Rational. */
+  bool operator<(const DyadicRational& lhs, const Rational& rhs);
+  /** Compare a DyadicRational with a Rational. */
+  bool operator<=(const DyadicRational& lhs, const Rational& rhs);
+  /** Compare a DyadicRational with a Rational. */
+  bool operator>(const DyadicRational& lhs, const Rational& rhs);
+  /** Compare a DyadicRational with a Rational. */
+  bool operator>=(const DyadicRational& lhs, const Rational& rhs);
+
+  /** Compare a Rational with a DyadicRational. */
+  bool operator==(const Rational& lhs, const DyadicRational& rhs);
+  /** Compare a Rational with a DyadicRational. */
+  bool operator!=(const Rational& lhs, const DyadicRational& rhs);
+  /** Compare a Rational with a DyadicRational. */
+  bool operator<(const Rational& lhs, const DyadicRational& rhs);
+  /** Compare a Rational with a DyadicRational. */
+  bool operator<=(const Rational& lhs, const DyadicRational& rhs);
+  /** Compare a Rational with a DyadicRational. */
+  bool operator>(const Rational& lhs, const DyadicRational& rhs);
+  /** Compare a Rational with a DyadicRational. */
+  bool operator>=(const Rational& lhs, const DyadicRational& rhs);
+
+  /** Swap two DyadicRationals. */
+  void swap(DyadicRational& lhs, DyadicRational& rhs);
+
+  /** Add two DyadicRationals. */
+  DyadicRational operator+(const DyadicRational& lhs,
+                           const DyadicRational& rhs);
+  /** Add a DyadicRational and an Integer. */
+  DyadicRational operator+(const DyadicRational& lhs, const Integer& rhs);
+  /** Add an Integer and a DyadicRational. */
+  DyadicRational operator+(const Integer& lhs, const DyadicRational& rhs);
+
+  /** Subtract two DyadicRationals. */
+  DyadicRational operator-(const DyadicRational& lhs,
+                           const DyadicRational& rhs);
+
+  /** Negate a DyadicRational. */
+  DyadicRational operator-(const DyadicRational& dr);
+
+  /** Multiply two DyadicRationals. */
+  DyadicRational operator*(const DyadicRational& lhs,
+                           const DyadicRational& rhs);
+
+  /** Compute lhs * 2^n. */
+  DyadicRational mul_2exp(const DyadicRational& lhs, unsigned long n);
+  /** Compute lhs^n. */
+  DyadicRational pow(const DyadicRational& lhs, unsigned long n);
+  /** Compute lhs / 2^n. */
+  DyadicRational div_2exp(const DyadicRational& lhs, unsigned long n);
+
+  /** Get the numerator of a DyadicRational. */
+  Integer numerator(const DyadicRational& r);
+  /** Get the denominator of a DyadicRational. */
+  Integer denominator(const DyadicRational& r);
+
+  /** Check if a DyadicRational is an integer. */
+  bool is_integer(const DyadicRational& r);
+
+  /** Compute the ceiling of a DyadicRational. */
+  Integer ceil(const DyadicRational& r);
+  /** Compute the floor of a DyadicRational. */
+  Integer floor(const DyadicRational& r);
+}  // namespace poly

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,11 @@ endif()
 
 set(polyxx_SOURCES
   polyxx/context.cpp
+  polyxx/dyadic_interval.cpp
+  polyxx/dyadic_rational.cpp
+  polyxx/integer_ring.cpp
+  polyxx/integer.cpp
+  polyxx/rational.cpp
   polyxx/variable.cpp
 )
 

--- a/src/polyxx/dyadic_interval.cpp
+++ b/src/polyxx/dyadic_interval.cpp
@@ -1,0 +1,273 @@
+#include "polyxx/dyadic_interval.h"
+
+#include <iostream>
+
+namespace poly {
+
+  DyadicInterval::DyadicInterval() {
+    lp_dyadic_interval_construct_zero(get_internal());
+  }
+  DyadicInterval::DyadicInterval(const DyadicRational& dr) {
+    lp_dyadic_interval_construct_point(get_internal(), dr.get_internal());
+  }
+  DyadicInterval::DyadicInterval(const DyadicRational& a,
+                                 const DyadicRational& b)
+      : DyadicInterval(a, true, b, true) {}
+  DyadicInterval::DyadicInterval(const DyadicRational& a, bool a_open,
+                                 const DyadicRational& b, bool b_open) {
+    lp_dyadic_interval_construct(get_internal(), a.get_internal(), a_open,
+                                 b.get_internal(), b_open);
+  }
+  DyadicInterval::DyadicInterval(const Integer& i)
+      : DyadicInterval(DyadicRational(i)) {}
+  DyadicInterval::DyadicInterval(const Integer& a, const Integer& b)
+      : DyadicInterval(a, true, b, true) {}
+  DyadicInterval::DyadicInterval(const Integer& a, bool a_open,
+                                 const Integer& b, bool b_open) {
+    lp_dyadic_interval_construct_from_integer(get_internal(), a.get_internal(),
+                                              a_open, b.get_internal(), b_open);
+  }
+  DyadicInterval::DyadicInterval(long a, long b)
+      : DyadicInterval(a, true, b, true) {}
+  DyadicInterval::DyadicInterval(long a, bool a_open, long b, bool b_open) {
+    lp_dyadic_interval_construct_from_int(get_internal(), a, a_open, b, b_open);
+  }
+
+  DyadicInterval::DyadicInterval(const DyadicInterval& i) {
+    lp_dyadic_interval_construct_copy(get_internal(), i.get_internal());
+  }
+  DyadicInterval::DyadicInterval(DyadicInterval&& i) {
+    lp_dyadic_interval_construct_copy(get_internal(), i.get_internal());
+  }
+
+  DyadicInterval::~DyadicInterval() {
+    lp_dyadic_interval_destruct(get_internal());
+  }
+
+  DyadicInterval& DyadicInterval::operator=(const DyadicInterval& i) {
+    lp_dyadic_interval_construct_copy(get_internal(), i.get_internal());
+    return *this;
+  }
+  DyadicInterval& DyadicInterval::operator=(DyadicInterval&& i) {
+    lp_dyadic_interval_construct_copy(get_internal(), i.get_internal());
+    return *this;
+  }
+
+  lp_dyadic_interval_t* DyadicInterval::get_internal() { return &mInterval; }
+
+  const lp_dyadic_interval_t* DyadicInterval::get_internal() const {
+    return &mInterval;
+  }
+
+  void DyadicInterval::collapse(const DyadicRational& dr) {
+    lp_dyadic_interval_collapse_to(get_internal(), dr.get_internal());
+  }
+  void DyadicInterval::set_lower(const DyadicRational& dr, bool open) {
+    lp_dyadic_interval_set_a(get_internal(), dr.get_internal(), open);
+  }
+  void DyadicInterval::set_upper(const DyadicRational& dr, bool open) {
+    lp_dyadic_interval_set_b(get_internal(), dr.get_internal(), open);
+  }
+  void DyadicInterval::scale(int n) {
+    lp_dyadic_interval_scale(get_internal(), n);
+  }
+
+  std::ostream& operator<<(std::ostream& os, const DyadicInterval& i) {
+    os << (i.get_internal()->a_open ? "( " : "[ ");
+    os << lp_dyadic_rational_to_string(&(i.get_internal()->a)) << " ; "
+       << lp_dyadic_rational_to_string(&(i.get_internal()->b));
+    os << (i.get_internal()->b_open ? " )" : " ]");
+    return os;
+  }
+
+  std::pair<DyadicInterval, DyadicInterval> split(const DyadicInterval& di,
+                                                  bool left_open,
+                                                  bool right_open) {
+    std::pair<DyadicInterval, DyadicInterval> res;
+    lp_dyadic_interval_construct_from_split(
+        res.first.get_internal(), res.second.get_internal(), di.get_internal(),
+        left_open ? 1 : 0, right_open ? 1 : 0);
+    return res;
+  }
+
+  void swap(DyadicInterval& lhs, DyadicInterval& rhs) {
+    lp_dyadic_interval_swap(lhs.get_internal(), rhs.get_internal());
+  }
+
+  bool operator==(const DyadicInterval& lhs, const DyadicInterval& rhs) {
+    return lp_dyadic_interval_equals(lhs.get_internal(), rhs.get_internal());
+  }
+  bool operator!=(const DyadicInterval& lhs, const DyadicInterval& rhs) {
+    return !(lhs == rhs);
+  }
+
+  bool contains(const DyadicInterval& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_interval_contains_dyadic_rational(lhs.get_internal(),
+                                                       rhs.get_internal());
+  }
+
+  bool contains_zero(const DyadicInterval& lhs) {
+    return lp_dyadic_interval_contains_zero(lhs.get_internal());
+  }
+
+  bool disjoint(const DyadicInterval& lhs, const DyadicInterval& rhs) {
+    return lp_dyadic_interval_disjoint(lhs.get_internal(), rhs.get_internal());
+  }
+
+  bool is_point(const DyadicInterval& di) {
+    return lp_dyadic_interval_is_point(di.get_internal());
+  }
+  DyadicRational get_point(const DyadicInterval& di) {
+    return DyadicRational(lp_dyadic_interval_get_point(di.get_internal()));
+  }
+  const DyadicRational& get_lower(const DyadicInterval& i) {
+    return *detail::cast_from(&i.get_internal()->a);
+  }
+  const DyadicRational& get_upper(const DyadicInterval& i) {
+    if (is_point(i)) {
+      return *detail::cast_from(&i.get_internal()->a);
+    } else {
+      return *detail::cast_from(&i.get_internal()->b);
+    }
+  }
+  int log_size(const DyadicInterval& di) {
+    return lp_dyadic_interval_size(di.get_internal());
+  }
+
+  int sgn(const DyadicInterval& di) {
+    return lp_dyadic_interval_sgn(di.get_internal());
+  }
+
+  bool operator==(const DyadicInterval& lhs, const Integer& rhs) {
+    return lp_dyadic_interval_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) == 0;
+  }
+  bool operator!=(const DyadicInterval& lhs, const Integer& rhs) {
+    return lp_dyadic_interval_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) != 0;
+  }
+  bool operator<(const DyadicInterval& lhs, const Integer& rhs) {
+    return lp_dyadic_interval_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) < 0;
+  }
+  bool operator<=(const DyadicInterval& lhs, const Integer& rhs) {
+    return lp_dyadic_interval_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) <= 0;
+  }
+  bool operator>(const DyadicInterval& lhs, const Integer& rhs) {
+    return lp_dyadic_interval_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) > 0;
+  }
+  bool operator>=(const DyadicInterval& lhs, const Integer& rhs) {
+    return lp_dyadic_interval_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const Integer& lhs, const DyadicInterval& rhs) {
+    return rhs == lhs;
+  }
+  bool operator!=(const Integer& lhs, const DyadicInterval& rhs) {
+    return rhs != lhs;
+  }
+  bool operator<(const Integer& lhs, const DyadicInterval& rhs) {
+    return rhs > lhs;
+  }
+  bool operator<=(const Integer& lhs, const DyadicInterval& rhs) {
+    return rhs >= lhs;
+  }
+  bool operator>(const Integer& lhs, const DyadicInterval& rhs) {
+    return rhs < lhs;
+  }
+  bool operator>=(const Integer& lhs, const DyadicInterval& rhs) {
+    return rhs <= lhs;
+  }
+
+  bool operator==(const DyadicInterval& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_interval_cmp_dyadic_rational(lhs.get_internal(),
+                                                  rhs.get_internal()) == 0;
+  }
+  bool operator!=(const DyadicInterval& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_interval_cmp_dyadic_rational(lhs.get_internal(),
+                                                  rhs.get_internal()) != 0;
+  }
+  bool operator<(const DyadicInterval& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_interval_cmp_dyadic_rational(lhs.get_internal(),
+                                                  rhs.get_internal()) < 0;
+  }
+  bool operator<=(const DyadicInterval& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_interval_cmp_dyadic_rational(lhs.get_internal(),
+                                                  rhs.get_internal()) <= 0;
+  }
+  bool operator>(const DyadicInterval& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_interval_cmp_dyadic_rational(lhs.get_internal(),
+                                                  rhs.get_internal()) > 0;
+  }
+  bool operator>=(const DyadicInterval& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_interval_cmp_dyadic_rational(lhs.get_internal(),
+                                                  rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const DyadicRational& lhs, const DyadicInterval& rhs) {
+    return rhs == lhs;
+  }
+  bool operator!=(const DyadicRational& lhs, const DyadicInterval& rhs) {
+    return rhs != lhs;
+  }
+  bool operator<(const DyadicRational& lhs, const DyadicInterval& rhs) {
+    return rhs > lhs;
+  }
+  bool operator<=(const DyadicRational& lhs, const DyadicInterval& rhs) {
+    return rhs >= lhs;
+  }
+  bool operator>(const DyadicRational& lhs, const DyadicInterval& rhs) {
+    return rhs < lhs;
+  }
+  bool operator>=(const DyadicRational& lhs, const DyadicInterval& rhs) {
+    return rhs <= lhs;
+  }
+
+  bool operator==(const DyadicInterval& lhs, const Rational& rhs) {
+    return lp_dyadic_interval_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) == 0;
+  }
+  bool operator!=(const DyadicInterval& lhs, const Rational& rhs) {
+    return lp_dyadic_interval_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) != 0;
+  }
+  bool operator<(const DyadicInterval& lhs, const Rational& rhs) {
+    return lp_dyadic_interval_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) < 0;
+  }
+  bool operator<=(const DyadicInterval& lhs, const Rational& rhs) {
+    return lp_dyadic_interval_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) <= 0;
+  }
+  bool operator>(const DyadicInterval& lhs, const Rational& rhs) {
+    return lp_dyadic_interval_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) > 0;
+  }
+  bool operator>=(const DyadicInterval& lhs, const Rational& rhs) {
+    return lp_dyadic_interval_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const Rational& lhs, const DyadicInterval& rhs) {
+    return rhs == lhs;
+  }
+  bool operator!=(const Rational& lhs, const DyadicInterval& rhs) {
+    return rhs != lhs;
+  }
+  bool operator<(const Rational& lhs, const DyadicInterval& rhs) {
+    return rhs > lhs;
+  }
+  bool operator<=(const Rational& lhs, const DyadicInterval& rhs) {
+    return rhs >= lhs;
+  }
+  bool operator>(const Rational& lhs, const DyadicInterval& rhs) {
+    return rhs < lhs;
+  }
+  bool operator>=(const Rational& lhs, const DyadicInterval& rhs) {
+    return rhs <= lhs;
+  }
+
+}  // namespace poly

--- a/src/polyxx/dyadic_rational.cpp
+++ b/src/polyxx/dyadic_rational.cpp
@@ -1,0 +1,260 @@
+#include "polyxx/dyadic_rational.h"
+
+#include <iostream>
+
+#include "polyxx/rational.h"
+
+namespace poly {
+
+  DyadicRational::DyadicRational() { lp_dyadic_rational_construct(&mDRat); }
+
+  DyadicRational::DyadicRational(const DyadicRational& r) {
+    lp_dyadic_rational_construct_copy(&mDRat, r.get_internal());
+  }
+  DyadicRational::DyadicRational(DyadicRational&& r) {
+    lp_dyadic_rational_construct_copy(&mDRat, r.get_internal());
+  }
+
+  DyadicRational::DyadicRational(long a, unsigned long n) {
+    lp_dyadic_rational_construct_from_int(&mDRat, a, n);
+  }
+  DyadicRational::DyadicRational(const Integer& i) {
+    lp_dyadic_rational_construct_from_integer(&mDRat, i.get_internal());
+  }
+  DyadicRational::DyadicRational(double d) {
+    lp_dyadic_rational_construct_from_double(&mDRat, d);
+  }
+  DyadicRational::DyadicRational(int i) : DyadicRational(i, 0) {}
+
+  DyadicRational::DyadicRational(const lp_dyadic_rational_t* dr) {
+    lp_dyadic_rational_construct_copy(&mDRat, dr);
+  }
+
+  DyadicRational::~DyadicRational() { lp_dyadic_rational_destruct(&mDRat); }
+
+  DyadicRational& DyadicRational::operator=(const DyadicRational& r) {
+    lp_dyadic_rational_assign(&mDRat, r.get_internal());
+    return *this;
+  }
+  DyadicRational& DyadicRational::operator=(DyadicRational&& r) {
+    lp_dyadic_rational_assign(&mDRat, r.get_internal());
+    return *this;
+  }
+
+  DyadicRational::operator Rational() const {
+    Rational res;
+    lp_rational_construct_from_dyadic(res.get_internal(), get_internal());
+    return res;
+  }
+
+  lp_dyadic_rational_t* DyadicRational::get_internal() { return &mDRat; }
+  const lp_dyadic_rational_t* DyadicRational::get_internal() const {
+    return &mDRat;
+  }
+
+  std::ostream& operator<<(std::ostream& os, const DyadicRational& r) {
+    return os << lp_dyadic_rational_to_string(r.get_internal());
+  }
+
+  double to_double(const DyadicRational& r) {
+    return lp_dyadic_rational_to_double(r.get_internal());
+  }
+
+  int sgn(const DyadicRational& r) {
+    return lp_dyadic_rational_sgn(r.get_internal());
+  }
+
+  bool operator==(const DyadicRational& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_rational_cmp(lhs.get_internal(), rhs.get_internal()) == 0;
+  }
+  bool operator!=(const DyadicRational& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_rational_cmp(lhs.get_internal(), rhs.get_internal()) != 0;
+  }
+  bool operator<(const DyadicRational& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_rational_cmp(lhs.get_internal(), rhs.get_internal()) < 0;
+  }
+  bool operator<=(const DyadicRational& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_rational_cmp(lhs.get_internal(), rhs.get_internal()) <= 0;
+  }
+  bool operator>(const DyadicRational& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_rational_cmp(lhs.get_internal(), rhs.get_internal()) > 0;
+  }
+  bool operator>=(const DyadicRational& lhs, const DyadicRational& rhs) {
+    return lp_dyadic_rational_cmp(lhs.get_internal(), rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const DyadicRational& lhs, const Integer& rhs) {
+    return lp_dyadic_rational_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) == 0;
+  }
+  bool operator!=(const DyadicRational& lhs, const Integer& rhs) {
+    return lp_dyadic_rational_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) != 0;
+  }
+  bool operator<(const DyadicRational& lhs, const Integer& rhs) {
+    return lp_dyadic_rational_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) < 0;
+  }
+  bool operator<=(const DyadicRational& lhs, const Integer& rhs) {
+    return lp_dyadic_rational_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) <= 0;
+  }
+  bool operator>(const DyadicRational& lhs, const Integer& rhs) {
+    return lp_dyadic_rational_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) > 0;
+  }
+  bool operator>=(const DyadicRational& lhs, const Integer& rhs) {
+    return lp_dyadic_rational_cmp_integer(lhs.get_internal(),
+                                          rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const Integer& lhs, const DyadicRational& rhs) {
+    return rhs == lhs;
+  }
+  bool operator!=(const Integer& lhs, const DyadicRational& rhs) {
+    return rhs != lhs;
+  }
+  bool operator<(const Integer& lhs, const DyadicRational& rhs) {
+    return rhs > lhs;
+  }
+  bool operator<=(const Integer& lhs, const DyadicRational& rhs) {
+    return rhs >= lhs;
+  }
+  bool operator>(const Integer& lhs, const DyadicRational& rhs) {
+    return rhs < lhs;
+  }
+  bool operator>=(const Integer& lhs, const DyadicRational& rhs) {
+    return rhs <= lhs;
+  }
+
+  bool operator==(const DyadicRational& lhs, const Rational& rhs) {
+    return lp_dyadic_rational_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) == 0;
+  }
+  bool operator!=(const DyadicRational& lhs, const Rational& rhs) {
+    return lp_dyadic_rational_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) != 0;
+  }
+  bool operator<(const DyadicRational& lhs, const Rational& rhs) {
+    return lp_dyadic_rational_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) < 0;
+  }
+  bool operator<=(const DyadicRational& lhs, const Rational& rhs) {
+    return lp_dyadic_rational_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) <= 0;
+  }
+  bool operator>(const DyadicRational& lhs, const Rational& rhs) {
+    return lp_dyadic_rational_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) > 0;
+  }
+  bool operator>=(const DyadicRational& lhs, const Rational& rhs) {
+    return lp_dyadic_rational_cmp_rational(lhs.get_internal(),
+                                           rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const Rational& lhs, const DyadicRational& rhs) {
+    return rhs == lhs;
+  }
+  bool operator!=(const Rational& lhs, const DyadicRational& rhs) {
+    return rhs != lhs;
+  }
+  bool operator<(const Rational& lhs, const DyadicRational& rhs) {
+    return rhs > lhs;
+  }
+  bool operator<=(const Rational& lhs, const DyadicRational& rhs) {
+    return rhs >= lhs;
+  }
+  bool operator>(const Rational& lhs, const DyadicRational& rhs) {
+    return rhs < lhs;
+  }
+  bool operator>=(const Rational& lhs, const DyadicRational& rhs) {
+    return rhs <= lhs;
+  }
+
+  void swap(DyadicRational& lhs, DyadicRational& rhs) {
+    lp_dyadic_rational_swap(lhs.get_internal(), rhs.get_internal());
+  }
+
+  DyadicRational operator+(const DyadicRational& lhs,
+                           const DyadicRational& rhs) {
+    DyadicRational res;
+    lp_dyadic_rational_add(res.get_internal(), lhs.get_internal(),
+                           rhs.get_internal());
+    return res;
+  }
+  DyadicRational operator+(const DyadicRational& lhs, const Integer& rhs) {
+    DyadicRational res;
+    lp_dyadic_rational_add_integer(res.get_internal(), lhs.get_internal(),
+                                   rhs.get_internal());
+    return res;
+  }
+  DyadicRational operator+(const Integer& lhs, const DyadicRational& rhs) {
+    return rhs + lhs;
+  }
+
+  DyadicRational operator-(const DyadicRational& lhs,
+                           const DyadicRational& rhs) {
+    DyadicRational res;
+    lp_dyadic_rational_sub(res.get_internal(), lhs.get_internal(),
+                           rhs.get_internal());
+    return res;
+  }
+  DyadicRational operator-(const DyadicRational& r) {
+    DyadicRational res;
+    lp_dyadic_rational_neg(res.get_internal(), r.get_internal());
+    return res;
+  }
+
+  DyadicRational operator*(const DyadicRational& lhs,
+                           const DyadicRational& rhs) {
+    DyadicRational res;
+    lp_dyadic_rational_mul(res.get_internal(), lhs.get_internal(),
+                           rhs.get_internal());
+    return res;
+  }
+
+  DyadicRational mul_2exp(const DyadicRational& lhs, unsigned long n) {
+    DyadicRational res;
+    lp_dyadic_rational_mul_2exp(res.get_internal(), lhs.get_internal(), n);
+    return res;
+  }
+
+  DyadicRational pow(const DyadicRational& r, unsigned long n) {
+    DyadicRational res;
+    lp_dyadic_rational_pow(res.get_internal(), r.get_internal(), n);
+    return res;
+  }
+
+  DyadicRational div_2exp(const DyadicRational& lhs, unsigned long n) {
+    DyadicRational res;
+    lp_dyadic_rational_div_2exp(res.get_internal(), lhs.get_internal(), n);
+    return res;
+  }
+
+  Integer numerator(const DyadicRational& r) {
+    Integer res;
+    lp_dyadic_rational_get_num(r.get_internal(), res.get_internal());
+    return res;
+  }
+  Integer denominator(const DyadicRational& r) {
+    Integer res;
+    lp_dyadic_rational_get_den(r.get_internal(), res.get_internal());
+    return res;
+  }
+
+  bool is_integer(const DyadicRational& r) {
+    return lp_dyadic_rational_is_integer(r.get_internal());
+  }
+
+  Integer ceil(const DyadicRational& r) {
+    Integer res;
+    lp_dyadic_rational_ceiling(r.get_internal(), res.get_internal());
+    return res;
+  }
+  Integer floor(const DyadicRational& r) {
+    Integer res;
+    lp_dyadic_rational_floor(r.get_internal(), res.get_internal());
+    return res;
+  }
+
+}  // namespace poly

--- a/test/polyxx/CMakeLists.txt
+++ b/test/polyxx/CMakeLists.txt
@@ -1,4 +1,8 @@
 set(polyxx_tests
+    test_dyadic_interval
+    test_dyadic_rational
+    test_integer
+    test_rational
     test_variable
 )
 

--- a/test/polyxx/test_dyadic_interval.cpp
+++ b/test/polyxx/test_dyadic_interval.cpp
@@ -1,0 +1,164 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <polyxx.h>
+
+#include "doctest.h"
+
+using namespace poly;
+
+TEST_CASE("dyadic_interval::constructors") {
+  CHECK(DyadicInterval() == DyadicInterval(Integer(0)));
+  CHECK(DyadicInterval(DyadicRational(1), DyadicRational(2)) ==
+        DyadicInterval(1, true, 2, true));
+  CHECK(DyadicInterval(Integer(1), Integer(2)) ==
+        DyadicInterval(1, true, 2, true));
+  CHECK(DyadicInterval(1, 2) == DyadicInterval(1, true, 2, true));
+}
+
+TEST_CASE("dyadic_interval::collapse") {
+  DyadicInterval di(1, 2);
+  di.collapse(17);
+  CHECK(di == Integer(17));
+}
+
+TEST_CASE("dyadic_interval::set_lower") {
+  DyadicInterval di(1, 2);
+  di.set_lower(0, false);
+  CHECK(di == DyadicInterval(0, false, 2, true));
+}
+
+TEST_CASE("dyadic_interval::set_upper") {
+  DyadicInterval di(1, 2);
+  di.set_upper(3, false);
+  CHECK(di == DyadicInterval(1, true, 3, false));
+}
+
+TEST_CASE("dyadic_interval::scale") {
+  {
+    DyadicInterval di(-1, 1);
+    di.scale(-2);
+    // TODO: https://github.com/SRI-CSL/libpoly/pull/26
+    // CHECK(di == DyadicInterval(DyadicRational(-1,2), DyadicRational(1,2)));
+  }
+  {
+    DyadicInterval di(-1, 1);
+    di.scale(2);
+    CHECK(di == DyadicInterval(-4, 4));
+  }
+}
+
+TEST_CASE("dyadic_interval::split") {
+  DyadicInterval di(Integer(0), Integer(10));
+  auto s = split(di, true, true);
+  CHECK(get_lower(di) == get_lower(s.first));
+  CHECK(get_upper(s.first) == get_lower(s.second));
+  CHECK(get_upper(di) == get_upper(s.second));
+  CHECK(disjoint(s.first, s.second));
+}
+
+TEST_CASE("dyadic_interval::swap") {
+  DyadicInterval a(Integer(1), Integer(2));
+  DyadicInterval b(Integer(3), Integer(4));
+  swap(a, b);
+  CHECK(a == DyadicInterval(Integer(3), Integer(4)));
+  CHECK(b == DyadicInterval(Integer(1), Integer(2)));
+}
+
+TEST_CASE("dyadic_interval::operator== / operator!=") {
+  DyadicInterval a(1, 2);
+  DyadicInterval b(DyadicRational(1), DyadicRational(2));
+  DyadicInterval c(Integer(3), Integer(4));
+  CHECK(a == a);
+  CHECK_FALSE(a != a);
+  CHECK(a == b);
+  CHECK_FALSE(a != b);
+  CHECK_FALSE(a == c);
+  CHECK(a != c);
+  CHECK(b == a);
+  CHECK_FALSE(b != a);
+  CHECK(b == b);
+  CHECK_FALSE(b != b);
+  CHECK_FALSE(b == c);
+  CHECK(b != c);
+  CHECK_FALSE(c == a);
+  CHECK(c != a);
+  CHECK_FALSE(c == b);
+  CHECK(c != b);
+  CHECK(c == c);
+  CHECK_FALSE(c != c);
+}
+
+TEST_CASE("dyadic_interval::contains") {
+  CHECK_FALSE(contains(DyadicInterval(1, 3), DyadicRational(0)));
+  CHECK_FALSE(contains(DyadicInterval(1, 3), DyadicRational(1)));
+  CHECK(contains(DyadicInterval(1, 3), DyadicRational(2)));
+  CHECK_FALSE(contains(DyadicInterval(1, 3), DyadicRational(3)));
+  CHECK_FALSE(contains(DyadicInterval(1, 3), DyadicRational(4)));
+}
+
+TEST_CASE("dyadic_interval::contains_zero") {
+  CHECK_FALSE(contains_zero(DyadicInterval(-2, -1)));
+  CHECK_FALSE(contains_zero(DyadicInterval(-1, 0)));
+  CHECK(contains_zero(DyadicInterval(-1, false, 0, false)));
+  CHECK_FALSE(contains_zero(DyadicInterval(-1, false, 0, true)));
+  CHECK(contains_zero(DyadicInterval(-1, true, 0, false)));
+  CHECK_FALSE(contains_zero(DyadicInterval(-1, true, 0, true)));
+  CHECK(contains_zero(DyadicInterval(-1, 1)));
+  CHECK(contains_zero(DyadicInterval(0, false, 1, false)));
+  CHECK(contains_zero(DyadicInterval(0, false, 1, true)));
+  CHECK_FALSE(contains_zero(DyadicInterval(0, true, 1, false)));
+  CHECK_FALSE(contains_zero(DyadicInterval(0, true, 1, true)));
+  CHECK_FALSE(contains_zero(DyadicInterval(1, 2)));
+}
+
+TEST_CASE("dyadic_interval::disjoint") {
+    CHECK(disjoint(DyadicInterval(1, 3), DyadicInterval(4, 6)));
+    CHECK(disjoint(DyadicInterval(1, 3), DyadicInterval(3, 4)));
+    CHECK(disjoint(DyadicInterval(1, 3), DyadicInterval(3, false, 4, false)));
+    CHECK(disjoint(DyadicInterval(1, false, 3, false), DyadicInterval(3, 4)));
+    CHECK_FALSE(disjoint(DyadicInterval(1, false, 3, false), DyadicInterval(3, false, 4, false)));
+    CHECK_FALSE(disjoint(DyadicInterval(1, 3), DyadicInterval(2, 4)));
+    CHECK_FALSE(disjoint(DyadicInterval(2, 4), DyadicInterval(2, 4)));
+    CHECK_FALSE(disjoint(DyadicInterval(2, 4), DyadicInterval(1, 3)));
+    CHECK(disjoint(DyadicInterval(3, 4), DyadicInterval(1, 3)));
+    CHECK(disjoint(DyadicInterval(3, 4), DyadicInterval(1, false, 3, false)));
+    CHECK(disjoint(DyadicInterval(3, false, 4, false), DyadicInterval(1, 3)));
+    CHECK_FALSE(disjoint(DyadicInterval(3, false, 4, false), DyadicInterval(1, false, 3, false)));
+    CHECK(disjoint(DyadicInterval(4, 6), DyadicInterval(1, 3)));
+}
+
+TEST_CASE("dyadic_interval::is_point") {
+    CHECK(is_point(DyadicInterval(3)));
+    CHECK_FALSE(is_point(DyadicInterval(3, true, 4, true)));
+    CHECK_FALSE(is_point(DyadicInterval(3, false, 4, false)));
+}
+
+TEST_CASE("dyadic_interval::get_lower") {
+    CHECK(get_lower(DyadicInterval(3)) == DyadicRational(3));
+    CHECK(get_lower(DyadicInterval(3, true, 4, true)) == DyadicRational(3));
+    CHECK(get_lower(DyadicInterval(3, false, 4, false)) == DyadicRational(3));
+}
+
+TEST_CASE("dyadic_interval::get_upper") {
+    CHECK(get_upper(DyadicInterval(3)) == DyadicRational(3));
+    CHECK(get_upper(DyadicInterval(2, true, 3, true)) == DyadicRational(3));
+    CHECK(get_upper(DyadicInterval(2, false, 3, false)) == DyadicRational(3));
+}
+
+TEST_CASE("dyadic_interval::log_size") {
+    CHECK(log_size(DyadicInterval(1)) == INT_MIN);
+    CHECK(log_size(DyadicInterval(1, 2)) == 1);
+    CHECK(log_size(DyadicInterval(1, 10)) == 4);
+}
+
+TEST_CASE("dyadic_interval::sgn") {
+    CHECK(sgn(DyadicInterval(-5)) == -1);
+    CHECK(sgn(DyadicInterval(-5, -4)) == -1);
+    CHECK(sgn(DyadicInterval(-1, 0)) == -1);
+    CHECK(sgn(DyadicInterval(-1, false, 0, false)) == 0);
+    CHECK(sgn(DyadicInterval(-1, 1)) == 0);
+    CHECK(sgn(DyadicInterval()) == 0);
+    CHECK(sgn(DyadicInterval(0, false, 1, false)) == 0);
+    CHECK(sgn(DyadicInterval(0, 1)) == 1);
+    CHECK(sgn(DyadicInterval(4, 5)) == 1);
+    CHECK(sgn(DyadicInterval(5)) == 1);
+}

--- a/test/polyxx/test_dyadic_interval.cpp
+++ b/test/polyxx/test_dyadic_interval.cpp
@@ -36,8 +36,7 @@ TEST_CASE("dyadic_interval::scale") {
   {
     DyadicInterval di(-1, 1);
     di.scale(-2);
-    // TODO: https://github.com/SRI-CSL/libpoly/pull/26
-    // CHECK(di == DyadicInterval(DyadicRational(-1,2), DyadicRational(1,2)));
+    CHECK(di == DyadicInterval(DyadicRational(-1,2), DyadicRational(1,2)));
   }
   {
     DyadicInterval di(-1, 1);

--- a/test/polyxx/test_dyadic_rational.cpp
+++ b/test/polyxx/test_dyadic_rational.cpp
@@ -1,0 +1,202 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <polyxx.h>
+
+#include "doctest.h"
+
+using namespace poly;
+
+TEST_CASE("dyadic_rational::constructors") {
+  CHECK(DyadicRational() == DyadicRational());
+  CHECK(DyadicRational() == DyadicRational(0, 1));
+  CHECK(DyadicRational(0.0) == DyadicRational(0, 1));
+  CHECK(DyadicRational(0.5) == DyadicRational(1, 1));
+  CHECK(DyadicRational(2) == DyadicRational(Integer(2)));
+}
+
+TEST_CASE("dyadic_rational::rational") {
+  CHECK(Rational(DyadicRational(2)) == Rational(Integer(2)));
+}
+
+TEST_CASE("dyadic_rational::to_double") {
+  CHECK(to_double(DyadicRational(Integer(1))) == 1.0);
+  CHECK(to_double(DyadicRational(Integer(2))) == 2.0);
+  CHECK(to_double(DyadicRational(1, 2)) == 0.25);
+  CHECK(to_double(DyadicRational(3, 2)) == 0.75);
+}
+
+TEST_CASE("dyadic_rational::sgn") {
+  CHECK(sgn(DyadicRational(-10)) == -1);
+  CHECK(sgn(DyadicRational(-1)) == -1);
+  CHECK(sgn(DyadicRational(0, 1)) == 0);
+  CHECK(sgn(DyadicRational(1)) == 1);
+  CHECK(sgn(DyadicRational(10)) == 1);
+}
+
+TEST_CASE("dyadic_rational::operator==") {
+  CHECK_FALSE(DyadicRational(1) == DyadicRational(2));
+  CHECK_FALSE(DyadicRational(1) == Integer(2));
+  CHECK_FALSE(Integer(1) == DyadicRational(2));
+  CHECK_FALSE(DyadicRational(1) == Rational(2));
+  CHECK_FALSE(Rational(1) == DyadicRational(2));
+  CHECK(DyadicRational(1) == DyadicRational(1));
+  CHECK(DyadicRational(1) == Integer(1));
+  CHECK(Integer(1) == DyadicRational(1));
+  CHECK(DyadicRational(1) == Rational(1));
+  CHECK(Rational(1) == DyadicRational(1));
+  CHECK_FALSE(DyadicRational(2) == DyadicRational(1));
+  CHECK_FALSE(DyadicRational(2) == Integer(1));
+  CHECK_FALSE(Integer(2) == DyadicRational(1));
+  CHECK_FALSE(DyadicRational(2) == Rational(1));
+  CHECK_FALSE(Rational(2) == DyadicRational(1));
+}
+
+TEST_CASE("dyadic_rational::operator!=") {
+  CHECK(DyadicRational(1) != DyadicRational(2));
+  CHECK(DyadicRational(1) != Integer(2));
+  CHECK(Integer(1) != DyadicRational(2));
+  CHECK(DyadicRational(1) != Rational(2));
+  CHECK(Rational(1) != DyadicRational(2));
+  CHECK_FALSE(DyadicRational(1) != DyadicRational(1));
+  CHECK_FALSE(DyadicRational(1) != Integer(1));
+  CHECK_FALSE(Integer(1) != DyadicRational(1));
+  CHECK_FALSE(DyadicRational(1) != Rational(1));
+  CHECK_FALSE(Rational(1) != DyadicRational(1));
+  CHECK(DyadicRational(2) != DyadicRational(1));
+  CHECK(DyadicRational(2) != Integer(1));
+  CHECK(Integer(2) != DyadicRational(1));
+  CHECK(DyadicRational(2) != Rational(1));
+  CHECK(Rational(2) != DyadicRational(1));
+}
+
+TEST_CASE("dyadic_rational::operator<") {
+  CHECK(DyadicRational(1) < DyadicRational(2));
+  CHECK(DyadicRational(1) < Integer(2));
+  CHECK(Integer(1) < DyadicRational(2));
+  CHECK(DyadicRational(1) < Rational(2));
+  CHECK(Rational(1) < DyadicRational(2));
+  CHECK_FALSE(DyadicRational(1) < DyadicRational(1));
+  CHECK_FALSE(DyadicRational(1) < Integer(1));
+  CHECK_FALSE(Integer(1) < DyadicRational(1));
+  CHECK_FALSE(DyadicRational(1) < Rational(1));
+  CHECK_FALSE(Rational(1) < DyadicRational(1));
+  CHECK_FALSE(DyadicRational(2) < DyadicRational(1));
+  CHECK_FALSE(DyadicRational(2) < Integer(1));
+  CHECK_FALSE(Integer(2) < DyadicRational(1));
+  CHECK_FALSE(DyadicRational(2) < Rational(1));
+  CHECK_FALSE(Rational(2) < DyadicRational(1));
+}
+
+TEST_CASE("dyadic_rational::operator<=") {
+  CHECK(DyadicRational(1) <= DyadicRational(2));
+  CHECK(DyadicRational(1) <= Integer(2));
+  CHECK(Integer(1) <= DyadicRational(2));
+  CHECK(DyadicRational(1) <= Rational(2));
+  CHECK(Rational(1) <= DyadicRational(2));
+  CHECK(DyadicRational(1) <= DyadicRational(1));
+  CHECK(DyadicRational(1) <= Integer(1));
+  CHECK(Integer(1) <= DyadicRational(1));
+  CHECK(DyadicRational(1) <= Rational(1));
+  CHECK(Rational(1) <= DyadicRational(1));
+  CHECK_FALSE(DyadicRational(2) <= DyadicRational(1));
+  CHECK_FALSE(DyadicRational(2) <= Integer(1));
+  CHECK_FALSE(Integer(2) <= DyadicRational(1));
+  CHECK_FALSE(DyadicRational(2) <= Rational(1));
+  CHECK_FALSE(Rational(2) <= DyadicRational(1));
+}
+
+TEST_CASE("dyadic_rational::operator>") {
+  CHECK_FALSE(DyadicRational(1) > DyadicRational(2));
+  CHECK_FALSE(DyadicRational(1) > Integer(2));
+  CHECK_FALSE(Integer(1) > DyadicRational(2));
+  CHECK_FALSE(DyadicRational(1) > Rational(2));
+  CHECK_FALSE(Rational(1) > DyadicRational(2));
+  CHECK_FALSE(DyadicRational(1) > DyadicRational(1));
+  CHECK_FALSE(DyadicRational(1) > Integer(1));
+  CHECK_FALSE(Integer(1) > DyadicRational(1));
+  CHECK_FALSE(DyadicRational(1) > Rational(1));
+  CHECK_FALSE(Rational(1) > DyadicRational(1));
+  CHECK(DyadicRational(2) > DyadicRational(1));
+  CHECK(DyadicRational(2) > Integer(1));
+  CHECK(Integer(2) > DyadicRational(1));
+  CHECK(DyadicRational(2) > Rational(1));
+  CHECK(Rational(2) > DyadicRational(1));
+}
+
+TEST_CASE("dyadic_rational::operator>=") {
+  CHECK_FALSE(DyadicRational(1) >= DyadicRational(2));
+  CHECK_FALSE(DyadicRational(1) >= Integer(2));
+  CHECK_FALSE(Integer(1) >= DyadicRational(2));
+  CHECK_FALSE(DyadicRational(1) >= Rational(2));
+  CHECK_FALSE(Rational(1) >= DyadicRational(2));
+  CHECK(DyadicRational(1) >= DyadicRational(1));
+  CHECK(DyadicRational(1) >= Integer(1));
+  CHECK(Integer(1) >= DyadicRational(1));
+  CHECK(DyadicRational(1) >= Rational(1));
+  CHECK(Rational(1) >= DyadicRational(1));
+  CHECK(DyadicRational(2) >= DyadicRational(1));
+  CHECK(DyadicRational(2) >= Integer(1));
+  CHECK(Integer(2) >= DyadicRational(1));
+  CHECK(DyadicRational(2) >= Rational(1));
+  CHECK(Rational(2) >= DyadicRational(1));
+}
+
+TEST_CASE("dyadic_rational::swap") {
+  DyadicRational a(1);
+  DyadicRational b(2);
+  swap(a, b);
+  CHECK(a == DyadicRational(2));
+  CHECK(b == DyadicRational(1));
+}
+
+TEST_CASE("dyadic_rational::operator+") {
+  CHECK(DyadicRational(1) + DyadicRational(2) == DyadicRational(3));
+  CHECK(DyadicRational(1) + Integer(2) == DyadicRational(3));
+  CHECK(Integer(1) + DyadicRational(2) == DyadicRational(3));
+}
+TEST_CASE("dyadic_rational::operator-") {
+  CHECK(DyadicRational(1) - DyadicRational(2) == DyadicRational(-1));
+  CHECK(-DyadicRational(1) == DyadicRational(-1));
+}
+
+TEST_CASE("dyadic_rational::operator*") {
+  CHECK(DyadicRational(1) * DyadicRational(2) == DyadicRational(2));
+}
+TEST_CASE("dyadic_rational::mul_2exp") {
+  CHECK(mul_2exp(DyadicRational(2), 2) == DyadicRational(8));
+}
+TEST_CASE("dyadic_rational::pow") {
+  CHECK(pow(DyadicRational(2), 3) == DyadicRational(8));
+}
+
+TEST_CASE("dyadic_rational::div_2exp") {
+  CHECK(div_2exp(DyadicRational(2), 1) == DyadicRational(Integer(1)));
+}
+
+TEST_CASE("dyadic_rational::numerator") {
+  CHECK(numerator(DyadicRational(1)) == Integer(1));
+  CHECK(numerator(DyadicRational(3, 4)) == Integer(3));
+  CHECK(numerator(DyadicRational(2, 4)) == Integer(1));
+}
+TEST_CASE("dyadic_rational::denominator") {
+  CHECK(denominator(DyadicRational(1)) == Integer(1));
+  CHECK(denominator(DyadicRational(1, 2)) == Integer(4));
+}
+
+TEST_CASE("dyadic_rational::is_integer") {
+  CHECK(is_integer(DyadicRational(1)));
+  CHECK(is_integer(DyadicRational(2)));
+  CHECK_FALSE(is_integer(DyadicRational(2, 4)));
+  CHECK(is_integer(DyadicRational(4, 2)));
+  CHECK_FALSE(is_integer(DyadicRational(3, 4)));
+}
+
+TEST_CASE("dyadic_rational::ceil") {
+  CHECK(ceil(DyadicRational(1)) == Integer(1));
+  CHECK(ceil(DyadicRational(1, 3)) == Integer(1));
+  CHECK(ceil(DyadicRational(7, 2)) == Integer(2));
+}
+TEST_CASE("dyadic_rational::floor") {
+  CHECK(floor(DyadicRational(1)) == Integer(1));
+  CHECK(floor(DyadicRational(1, 3)) == Integer(0));
+  CHECK(floor(DyadicRational(7, 2)) == Integer(1));
+}


### PR DESCRIPTION
This PR depends on #30. It adds new wrapper classes for `lp_dyadic_rational_t` (`DyadicRational`) and `lp_dyadic_interval_t` (`DyadicInterval`). Both classes induce no memory overhead, which allows for easy (and fast) conversions of arrays by a simple cast.
Most of the C interface is exported in the C++ interface as well and unit tests are added.