### PR TITLE
Add casts to and from mpz_class and mpq_class.

### DIFF
--- a/include/polyxx/integer.h
+++ b/include/polyxx/integer.h
@@ -77,6 +77,8 @@ namespace poly {
   /** Make sure that we can cast between Integer and lp_integer_t. */
   static_assert(sizeof(Integer) == sizeof(lp_integer_t),
                 "Please check the size of Integer.");
+  static_assert(sizeof(Integer) == sizeof(mpz_class),
+                "Please check the size of Integer.");
   namespace detail {
     /** Non-const cast from an Integer to a lp_integer_t. */
     inline lp_integer_t* cast_to(Integer* i) {
@@ -86,12 +88,28 @@ namespace poly {
     inline const lp_integer_t* cast_to(const Integer* i) {
       return reinterpret_cast<const lp_integer_t*>(i);
     }
+    /** Non-const cast from an Integer to a mpz_class. */
+    inline mpz_class* cast_to_gmp(Integer* i) {
+      return reinterpret_cast<mpz_class*>(i);
+    }
+    /** Const cast from an Integer to a mpz_class. */
+    inline const mpz_class* cast_to_gmp(const Integer* i) {
+      return reinterpret_cast<const mpz_class*>(i);
+    }
     /** Non-const cast from a lp_integer_t to an Integer. */
     inline Integer* cast_from(lp_integer_t* i) {
       return reinterpret_cast<Integer*>(i);
     }
     /** Const cast from a lp_integer_t to an Integer. */
     inline const Integer* cast_from(const lp_integer_t* i) {
+      return reinterpret_cast<const Integer*>(i);
+    }
+    /** Non-const cast from a mpz_class to an Integer. */
+    inline Integer* cast_from(mpz_class* i) {
+      return reinterpret_cast<Integer*>(i);
+    }
+    /** Const cast from a mpz_class to an Integer. */
+    inline const Integer* cast_from(const mpz_class* i) {
       return reinterpret_cast<const Integer*>(i);
     }
   }  // namespace detail

--- a/include/polyxx/rational.h
+++ b/include/polyxx/rational.h
@@ -54,6 +54,8 @@ namespace poly {
   /** Make sure that we can cast between Rational and lp_rational_t. */
   static_assert(sizeof(Rational) == sizeof(lp_rational_t),
                 "Please check the size of Rational.");
+  static_assert(sizeof(Rational) == sizeof(mpq_class),
+                "Please check the size of Rational.");
   namespace detail {
     /** Non-const cast from a Rational to a lp_rational_t. */
     inline lp_rational_t* cast_to(Rational* i) {
@@ -63,12 +65,28 @@ namespace poly {
     inline const lp_rational_t* cast_to(const Rational* i) {
       return reinterpret_cast<const lp_rational_t*>(i);
     }
+    /** Non-const cast from an Rational to a mpz_class. */
+    inline mpq_class* cast_to_gmp(Rational* i) {
+      return reinterpret_cast<mpq_class*>(i);
+    }
+    /** Const cast from an Rational to a mpz_class. */
+    inline const mpq_class* cast_to_gmp(const Rational* i) {
+      return reinterpret_cast<const mpq_class*>(i);
+    }
     /** Non-const cast from a lp_rational_t to a Rational. */
     inline Rational* cast_from(lp_rational_t* i) {
       return reinterpret_cast<Rational*>(i);
     }
     /** Const cast from a lp_rational_t to a Rational. */
     inline const Rational* cast_from(const lp_rational_t* i) {
+      return reinterpret_cast<const Rational*>(i);
+    }
+    /** Non-const cast from a mpq_class to a Rational. */
+    inline Rational* cast_from(mpq_class* i) {
+      return reinterpret_cast<Rational*>(i);
+    }
+    /** Const cast from a mpq_class to a Rational. */
+    inline const Rational* cast_from(const mpq_class* i) {
       return reinterpret_cast<const Rational*>(i);
     }
   }  // namespace detail


### PR DESCRIPTION
During further integration, it turned out that additional cases to and from `mpz_class` and `mpq_class` (like the one between the new C++ classes and the underlying C structs) are very convenient. This PR adds these casts.