### PR TITLE
Adding wrapper classes for lp_upolynomial_t and lp_algebraic_number_t

### DIFF
--- a/include/polyxx.h
+++ b/include/polyxx.h
@@ -2,10 +2,12 @@
 
 #include "poly.h"
 
+#include "polyxx/algebraic_number.h"
 #include "polyxx/context.h"
 #include "polyxx/dyadic_interval.h"
 #include "polyxx/dyadic_rational.h"
 #include "polyxx/integer.h"
 #include "polyxx/integer_ring.h"
 #include "polyxx/rational.h"
+#include "polyxx/upolynomial.h"
 #include "polyxx/variable.h"

--- a/include/polyxx/algebraic_number.h
+++ b/include/polyxx/algebraic_number.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <iosfwd>
+
+#include "../algebraic_number.h"
+#include "dyadic_interval.h"
+#include "dyadic_rational.h"
+#include "integer.h"
+#include "upolynomial.h"
+
+namespace poly {
+
+  /**
+   * Implements a wrapper for lp_algebraic_number_t from libpoly.
+   */
+  class AlgebraicNumber {
+    /** The actual algebraic number. */
+    lp_algebraic_number_t mValue;
+
+   public:
+    /** Copy from an internal lp_algebraic_number_t pointer. */
+    explicit AlgebraicNumber(const lp_algebraic_number_t* an);
+    /** Construct as zero. */
+    AlgebraicNumber();
+    /** Copy from the given AlgebraicNumber. */
+    AlgebraicNumber(const AlgebraicNumber& an);
+    /** Move from the given AlgebraicNumber. */
+    AlgebraicNumber(AlgebraicNumber&& an);
+
+    /** Construct from a DyadicRational */
+    AlgebraicNumber(const DyadicRational& dr);
+
+    /** Construct from a defining polynomial and an isolating interval. */
+    AlgebraicNumber(UPolynomial&& poly, const DyadicInterval& di);
+    /** Construct from a defining polynomial and an isolating interval. */
+    AlgebraicNumber(const UPolynomial& poly, const DyadicInterval& di);
+    /** Custom destructor. */
+    ~AlgebraicNumber();
+    /** Copy from the given AlgebraicNumber. */
+    AlgebraicNumber& operator=(const AlgebraicNumber& an);
+    /** Move from the given AlgebraicNumber. */
+    AlgebraicNumber& operator=(AlgebraicNumber&& an);
+
+    /** Get a non-const pointer to the internal lp_algebraic_number_t. Handle
+     * with care! */
+    lp_algebraic_number_t* get_internal();
+    /** Get a const pointer to the internal lp_algebraic_number_t. */
+    const lp_algebraic_number_t* get_internal() const;
+  };
+
+  /** Make sure that we can cast between AlgebraicNumber and
+   * lp_algebraic_number_t. */
+  static_assert(sizeof(AlgebraicNumber) == sizeof(lp_algebraic_number_t),
+                "Please check the size of AlgebraicNumber.");
+  namespace detail {
+    /** Non-const cast from an AlgebraicNumber to a lp_algebraic_number_t. */
+    inline lp_algebraic_number_t* cast_to(AlgebraicNumber* i) {
+      return reinterpret_cast<lp_algebraic_number_t*>(i);
+    }
+    /** Const cast from an AlgebraicNumber to a lp_algebraic_number_t. */
+    inline const lp_algebraic_number_t* cast_to(const AlgebraicNumber* i) {
+      return reinterpret_cast<const lp_algebraic_number_t*>(i);
+    }
+    /** Non-const cast from a lp_algebraic_number_t to an AlgebraicNumber. */
+    inline AlgebraicNumber* cast_from(lp_algebraic_number_t* i) {
+      return reinterpret_cast<AlgebraicNumber*>(i);
+    }
+    /** Const cast from a lp_algebraic_number_t to an AlgebraicNumber. */
+    inline const AlgebraicNumber* cast_from(const lp_algebraic_number_t* i) {
+      return reinterpret_cast<const AlgebraicNumber*>(i);
+    }
+  }  // namespace detail
+
+  /** Stream the given AlgebraicNumber to an output stream. */
+  std::ostream& operator<<(std::ostream& os, const AlgebraicNumber& an);
+
+  /** Swap two algebraic numbers. */
+  void swap(AlgebraicNumber& lhs, AlgebraicNumber& rhs);
+  /** Compute the sign of an algebraic number. */
+  int sgn(const AlgebraicNumber& an);
+
+  /** Compare two algebraic numbers. */
+  bool operator==(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs);
+  /** Compare two algebraic numbers. */
+  bool operator!=(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs);
+  /** Compare two algebraic numbers. */
+  bool operator<(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs);
+  /** Compare two algebraic numbers. */
+  bool operator<=(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs);
+  /** Compare two algebraic numbers. */
+  bool operator>(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs);
+  /** Compare two algebraic numbers. */
+  bool operator>=(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs);
+
+  /** Compare an algebraic number and an integer. */
+  bool operator==(const AlgebraicNumber& lhs, const Integer& rhs);
+  /** Compare an algebraic number and an integer. */
+  bool operator!=(const AlgebraicNumber& lhs, const Integer& rhs);
+  /** Compare an algebraic number and an integer. */
+  bool operator<(const AlgebraicNumber& lhs, const Integer& rhs);
+  /** Compare an algebraic number and an integer. */
+  bool operator<=(const AlgebraicNumber& lhs, const Integer& rhs);
+  /** Compare an algebraic number and an integer. */
+  bool operator>(const AlgebraicNumber& lhs, const Integer& rhs);
+  /** Compare an algebraic number and an integer. */
+  bool operator>=(const AlgebraicNumber& lhs, const Integer& rhs);
+
+  /** Compare an integer and an algebraic number. */
+  bool operator==(const Integer& lhs, const AlgebraicNumber& rhs);
+  /** Compare an integer and an algebraic number. */
+  bool operator!=(const Integer& lhs, const AlgebraicNumber& rhs);
+  /** Compare an integer and an algebraic number. */
+  bool operator<(const Integer& lhs, const AlgebraicNumber& rhs);
+  /** Compare an integer and an algebraic number. */
+  bool operator<=(const Integer& lhs, const AlgebraicNumber& rhs);
+  /** Compare an integer and an algebraic number. */
+  bool operator>(const Integer& lhs, const AlgebraicNumber& rhs);
+  /** Compare an integer and an algebraic number. */
+  bool operator>=(const Integer& lhs, const AlgebraicNumber& rhs);
+
+  /** Compare an algebraic number and a dyadic rational. */
+  bool operator==(const AlgebraicNumber& lhs, const DyadicRational& rhs);
+  /** Compare an algebraic number and a dyadic rational. */
+  bool operator!=(const AlgebraicNumber& lhs, const DyadicRational& rhs);
+  /** Compare an algebraic number and a dyadic rational. */
+  bool operator<(const AlgebraicNumber& lhs, const DyadicRational& rhs);
+  /** Compare an algebraic number and a dyadic rational. */
+  bool operator<=(const AlgebraicNumber& lhs, const DyadicRational& rhs);
+  /** Compare an algebraic number and a dyadic rational. */
+  bool operator>(const AlgebraicNumber& lhs, const DyadicRational& rhs);
+  /** Compare an algebraic number and a dyadic rational. */
+  bool operator>=(const AlgebraicNumber& lhs, const DyadicRational& rhs);
+
+  /** Compare a dyadic rational and an algebraic number. */
+  bool operator==(const DyadicRational& lhs, const AlgebraicNumber& rhs);
+  /** Compare a dyadic rational and an algebraic number. */
+  bool operator!=(const DyadicRational& lhs, const AlgebraicNumber& rhs);
+  /** Compare a dyadic rational and an algebraic number. */
+  bool operator<(const DyadicRational& lhs, const AlgebraicNumber& rhs);
+  /** Compare a dyadic rational and an algebraic number. */
+  bool operator<=(const DyadicRational& lhs, const AlgebraicNumber& rhs);
+  /** Compare a dyadic rational and an algebraic number. */
+  bool operator>(const DyadicRational& lhs, const AlgebraicNumber& rhs);
+  /** Compare a dyadic rational and an algebraic number. */
+  bool operator>=(const DyadicRational& lhs, const AlgebraicNumber& rhs);
+
+  /** Compare an algebraic number and a rational. */
+  bool operator==(const AlgebraicNumber& lhs, const Rational& rhs);
+  /** Compare an algebraic number and a rational. */
+  bool operator!=(const AlgebraicNumber& lhs, const Rational& rhs);
+  /** Compare an algebraic number and a rational. */
+  bool operator<(const AlgebraicNumber& lhs, const Rational& rhs);
+  /** Compare an algebraic number and a rational. */
+  bool operator<=(const AlgebraicNumber& lhs, const Rational& rhs);
+  /** Compare an algebraic number and a rational. */
+  bool operator>(const AlgebraicNumber& lhs, const Rational& rhs);
+  /** Compare an algebraic number and a rational. */
+  bool operator>=(const AlgebraicNumber& lhs, const Rational& rhs);
+
+  /** Compare a rational and an algebraic number. */
+  bool operator==(const Rational& lhs, const AlgebraicNumber& rhs);
+  /** Compare a rational and an algebraic number. */
+  bool operator!=(const Rational& lhs, const AlgebraicNumber& rhs);
+  /** Compare a rational and an algebraic number. */
+  bool operator<(const Rational& lhs, const AlgebraicNumber& rhs);
+  /** Compare a rational and an algebraic number. */
+  bool operator<=(const Rational& lhs, const AlgebraicNumber& rhs);
+  /** Compare a rational and an algebraic number. */
+  bool operator>(const Rational& lhs, const AlgebraicNumber& rhs);
+  /** Compare a rational and an algebraic number. */
+  bool operator>=(const Rational& lhs, const AlgebraicNumber& rhs);
+
+  /** Give a double approximation. */
+  double to_double(const AlgebraicNumber& an);
+  /** Give a rational approximation. */
+  Rational to_rational_approximation(const AlgebraicNumber& an);
+
+  /** Get lower bound of the isolating interval. */
+  const DyadicRational& get_lower_bound(const AlgebraicNumber& an);
+  /** Get upper bound of the isolating interval. */
+  const DyadicRational& get_upper_bound(const AlgebraicNumber& an);
+  /** Get the midpoint of the isolating interval. */
+  DyadicRational midpoint_dyadic(const AlgebraicNumber& an);
+  /** Get the midpoint of the isolating interval. */
+  Rational midpoint_rational(const AlgebraicNumber& an);
+  /** Refine the isolating interval. */
+  void refine(AlgebraicNumber& an);
+  /** Refine the isolating interval of a const algebraic number. */
+  void refine_const(const AlgebraicNumber& an);
+
+  /** Add two algebraic numbers. */
+  AlgebraicNumber operator+(const AlgebraicNumber& lhs,
+                            const AlgebraicNumber& rhs);
+  /** Subtract two algebraic numbers. */
+  AlgebraicNumber operator-(const AlgebraicNumber& lhs,
+                            const AlgebraicNumber& rhs);
+  /** Negate a algebraic number. */
+  AlgebraicNumber operator-(const AlgebraicNumber& an);
+  /** Multiply two algebraic numbers. */
+  AlgebraicNumber operator*(const AlgebraicNumber& lhs,
+                            const AlgebraicNumber& rhs);
+  /** Compute lhs^n. */
+  AlgebraicNumber pow(const AlgebraicNumber& lhs, unsigned n);
+
+  /** Check whether an algebraic number is a rational.
+   * This check is not complete.
+   */
+  bool is_rational(const AlgebraicNumber& an);
+  /** Check whether an algebraic number is an integer. */
+  bool is_integer(const AlgebraicNumber& an);
+  /** Checks whether an algebraic number is zero. */
+  bool is_zero(const AlgebraicNumber& an);
+  /** Checks whether an algebraic number is one. */
+  bool is_one(const AlgebraicNumber& an);
+
+  /** Compute the ceiling of an algebraic number. */
+  Integer ceil(const AlgebraicNumber& an);
+  /** Compute the floor of an algebraic number. */
+  Integer floor(const AlgebraicNumber& an);
+
+}  // namespace poly

--- a/include/polyxx/upolynomial.h
+++ b/include/polyxx/upolynomial.h
@@ -1,0 +1,224 @@
+#pragma once
+
+#include <iosfwd>
+#include <utility>
+#include <vector>
+
+#include "../integer.h"
+#include "../upolynomial.h"
+#include "dyadic_rational.h"
+#include "integer.h"
+#include "integer_ring.h"
+#include "rational.h"
+#include "variable.h"
+
+namespace poly {
+
+  /**
+   * Implements a wrapper for lp_upolynomial_t from libpoly.
+   */
+  class UPolynomial {
+    /** The actual univariate polynomial. */
+    deleting_unique_ptr<lp_upolynomial_t> mPoly;
+
+   public:
+    /** Create from a lp_upolynomial_t pointer, claiming it's ownership. */
+    explicit UPolynomial(lp_upolynomial_t* poly);
+    /** Copy from an internal lp_upolynomial_t pointer. */
+    explicit UPolynomial(const lp_upolynomial_t* poly);
+
+    /** Create the zero polynomial. */
+    explicit UPolynomial();
+    /** Create a constant polynomial. */
+    explicit UPolynomial(const Integer& i);
+    /** Create a constant polynomial. */
+    explicit UPolynomial(long i);
+
+    /** Create from integer coefficients. */
+    explicit UPolynomial(const std::vector<Integer>& coefficients);
+    /** Create from integer coefficients into the given integer ring. */
+    UPolynomial(const IntegerRing& ir, const std::vector<Integer>& coefficients);
+    /** Create from integer coefficients. */
+    explicit UPolynomial(const std::vector<long>& coefficients);
+    /** Create from integer coefficients into the given integer ring. */
+    UPolynomial(const IntegerRing& ir, const std::vector<long>& coefficients);
+
+    /** Create from integer coefficients. */
+    explicit UPolynomial(std::initializer_list<long> coefficients);
+    /** Create from integer coefficients into the given integer ring. */
+    UPolynomial(const IntegerRing& ir, std::initializer_list<long> coefficients);
+
+    /** Construct c * x^degree. */
+    UPolynomial(std::size_t degree, long c);
+    /** Construct c * x^degree into the given integer ring. */
+    UPolynomial(const IntegerRing& ir, std::size_t degree, long c);
+
+    /** Copy from a polynomial. */
+    UPolynomial(const UPolynomial& poly);
+    /** Move from a polynomial. */
+    UPolynomial(UPolynomial&& poly);
+    /** Copy from a polynomial into the given integer ring. */
+    UPolynomial(const IntegerRing& ir, const UPolynomial& poly);
+
+    /** Copy from a polynomial. */
+    UPolynomial& operator=(const UPolynomial& poly);
+    /** Move from a polynomial. */
+    UPolynomial& operator=(UPolynomial&& poly);
+    /** Assign from and take ownership of an internal lp_upolynomial_t pointer.
+     */
+    UPolynomial& operator=(lp_upolynomial_t* poly);
+
+    /** Get a non-const pointer to the internal lp_upolynomial_t. Handle with
+     * care! */
+    lp_upolynomial_t* get_internal();
+    /** Get a const pointer to the internal lp_upolynomial_t. */
+    const lp_upolynomial_t* get_internal() const;
+    /** Release the lp_upolynomial_t pointer. This yields ownership of the
+     * returned pointer. */
+    lp_upolynomial_t* release();
+  };
+
+  /** Return the degree of a polynomial. */
+  std::size_t degree(const UPolynomial& p);
+
+  /** Get the leading coefficient. */
+  const Integer& leading_coefficient(const UPolynomial& p);
+  /** Get the constant coefficient. */
+  const Integer& constant_coefficient(const UPolynomial& p);
+
+  /** Get all coefficients. */
+  std::vector<Integer> coefficients(const UPolynomial& p);
+
+  /** Stream the given UPolynomial to an output stream. */
+  std::ostream& operator<<(std::ostream& os, const UPolynomial& p);
+
+  /** Check if the polynomial is zero. */
+  bool is_zero(const UPolynomial& p);
+  /** Check if the polynomial is one. */
+  bool is_one(const UPolynomial& p);
+  /** Check if the polynomial is monic.
+   * A polynomial is monic if its leading coefficient is one.
+   */
+  bool is_monic(const UPolynomial& p);
+  /** Check if the polynomial is primitive.
+   * A polynomial is primitive if the gcd of all coefficients is one and the
+   * leading coefficient is positive.
+   */
+  bool is_primitive(const UPolynomial& p);
+
+  /** Evaluate a polynomial at an integer. */
+  Integer evaluate_at(const UPolynomial& p, const Integer& i);
+  /** Evaluate a polynomial at a rational. */
+  Rational evaluate_at(const UPolynomial& p, const Rational& r);
+  /** Evaluate a polynomial at a dyadic rational. */
+  DyadicRational evaluate_at(const UPolynomial& p, const DyadicRational& dr);
+
+  /** Determine the sign of a polynomial at an integer. */
+  int sign_at(const UPolynomial& p, const Integer& i);
+  /** Determine the sign of a polynomial at a rational. */
+  int sign_at(const UPolynomial& p, const Rational& r);
+  /** Determine the sign of a polynomial at a dyadic rational. */
+  int sign_at(const UPolynomial& p, const DyadicRational& dr);
+
+  /** Compares two polynomials (using a lexicographic order on the
+   * coefficients). */
+  bool operator==(const UPolynomial& lhs, const UPolynomial& rhs);
+  /** Compares two polynomials (using a lexicographic order on the
+   * coefficients). */
+  bool operator!=(const UPolynomial& lhs, const UPolynomial& rhs);
+  /** Compares two polynomials (using a lexicographic order on the
+   * coefficients). */
+  bool operator<(const UPolynomial& lhs, const UPolynomial& rhs);
+  /** Compares two polynomials (using a lexicographic order on the
+   * coefficients). */
+  bool operator<=(const UPolynomial& lhs, const UPolynomial& rhs);
+  /** Compares two polynomials (using a lexicographic order on the
+   * coefficients). */
+  bool operator>(const UPolynomial& lhs, const UPolynomial& rhs);
+  /** Compares two polynomials (using a lexicographic order on the
+   * coefficients). */
+  bool operator>=(const UPolynomial& lhs, const UPolynomial& rhs);
+
+  /** Compute p(-x). */
+  UPolynomial subst_x_neg(const UPolynomial& p);
+  /** Compute -p. */
+  UPolynomial operator-(const UPolynomial& p);
+  /** Negate a polynomial in place. */
+  void neg(UPolynomial& p);
+
+  /** Add two polynomials. */
+  UPolynomial operator+(const UPolynomial& lhs, const UPolynomial& rhs);
+  /** Subtract two polynomials. */
+  UPolynomial operator-(const UPolynomial& lhs, const UPolynomial& rhs);
+  /** Multiply two polynomials. */
+  UPolynomial operator*(const UPolynomial& lhs, const UPolynomial& rhs);
+  /** Multiply a polynomial and an integer. */
+  UPolynomial operator*(const UPolynomial& lhs, const Integer& rhs);
+  /** Multiply an integer and a polynomial. */
+  UPolynomial operator*(const Integer& lhs, const UPolynomial& rhs);
+
+  /** Compute lhs^rhs. */
+  UPolynomial pow(const UPolynomial& lhs, long rhs);
+
+  /** Compute the first derivative. */
+  UPolynomial derivative(const UPolynomial& p);
+
+  /** Check whether lhs divides rhs. */
+  bool divides(const UPolynomial& lhs, const UPolynomial& rhs);
+
+  /** Divide all degrees within lhs by rhs. All degrees (with non-zero
+   * coefficients) must be divisible by rhs. */
+  UPolynomial div_degrees(const UPolynomial& lhs, long rhs);
+
+  /** Divides two polynomials, assuming all necessary inverses can be computed.
+   */
+  UPolynomial div_exact(const UPolynomial& lhs, const UPolynomial& rhs);
+  /** Divides a polynomial by an integer, assuming that all coefficients are
+   * divisible by rhs. */
+  UPolynomial div_exact(const UPolynomial& lhs, const Integer& rhs);
+  /** Computes the remainder of two polynomials, assuming all necessary inverses
+   * can be computed. */
+  UPolynomial rem_exact(const UPolynomial& lhs, const UPolynomial& rhs);
+  /** Computes the quotient and the remainder of two polynomials, assuming all
+   * necessary inverses can be computed. */
+  std::pair<UPolynomial, UPolynomial> div_rem_exact(const UPolynomial& lhs,
+                                                    const UPolynomial& rhs);
+  /** Performs pseudo-division such that
+   *  lc(rhs)^(lhs_deg - rhs_deg + 1) * lhs = div * rhs + rem
+   * and returns (div, rem).
+   */
+  std::pair<UPolynomial, UPolynomial> div_rem_pseudo(const UPolynomial& lhs,
+                                                     const UPolynomial& rhs);
+
+  /** Computes the content of a polynomial.
+   * The content is the gcd of all coefficients with the sign of the leading
+   * coefficient.
+   */
+  Integer content(const UPolynomial& p);
+  /** Makes a polynomial primitive in place.
+   * A polynomial is primitive if its content is one.
+   */
+  void make_primitive(UPolynomial& p);
+  /** Computes the primitive part, that is p / content(p). */
+  UPolynomial primitive_part(const UPolynomial& p);
+
+  /** Compute the greatest common divisor. */
+  UPolynomial gcd(const UPolynomial& lhs, const UPolynomial& rhs);
+  /** Compute the extended greatest common divisor. */
+  UPolynomial extended_gcd(const UPolynomial& lhs, const UPolynomial& rhs,
+                           UPolynomial& u, UPolynomial& v);
+  /** Solves the equations
+   *  u * p + v * q = r
+   * assuming that gcd(p,q) divides r.
+   */
+  void solve_bezout(const UPolynomial& p, const UPolynomial& q,
+                    const UPolynomial& r, UPolynomial& u, UPolynomial& v);
+
+  /** Compute a square-free factorization of a polynomial. */
+  std::vector<UPolynomial> square_free_factors(const UPolynomial& p,
+                                               bool with_constant = false);
+
+  /** Compute the sturm sequence of a polynomial. */
+  std::vector<UPolynomial> sturm_sequence(const UPolynomial& p);
+
+}  // namespace poly

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,12 +42,14 @@ if (NOT HAVE_OPEN_MEMSTREAM)
 endif()
 
 set(polyxx_SOURCES
+  polyxx/algebraic_number.cpp
   polyxx/context.cpp
   polyxx/dyadic_interval.cpp
   polyxx/dyadic_rational.cpp
   polyxx/integer_ring.cpp
   polyxx/integer.cpp
   polyxx/rational.cpp
+  polyxx/upolynomial.cpp
   polyxx/variable.cpp
 )
 

--- a/src/polyxx/algebraic_number.cpp
+++ b/src/polyxx/algebraic_number.cpp
@@ -1,0 +1,305 @@
+#include "polyxx/algebraic_number.h"
+
+#include <iostream>
+
+namespace poly {
+
+  AlgebraicNumber::AlgebraicNumber(const lp_algebraic_number_t* an) {
+    lp_algebraic_number_construct_copy(get_internal(), an);
+  }
+  AlgebraicNumber::AlgebraicNumber() {
+    lp_algebraic_number_construct_zero(get_internal());
+  }
+  AlgebraicNumber::AlgebraicNumber(const AlgebraicNumber& an) {
+    lp_algebraic_number_construct_copy(get_internal(), an.get_internal());
+  }
+  AlgebraicNumber::AlgebraicNumber(AlgebraicNumber&& an) : AlgebraicNumber() {
+    swap(*this, an);
+  }
+  AlgebraicNumber::AlgebraicNumber(const DyadicRational& dr) {
+    lp_algebraic_number_construct_from_dyadic_rational(get_internal(),
+                                                       dr.get_internal());
+  }
+
+  AlgebraicNumber::AlgebraicNumber(UPolynomial&& poly,
+                                   const DyadicInterval& di) {
+    lp_algebraic_number_construct(get_internal(), poly.release(),
+                                  di.get_internal());
+  }
+  AlgebraicNumber::AlgebraicNumber(const UPolynomial& poly,
+                                   const DyadicInterval& di) {
+    lp_algebraic_number_construct(get_internal(), UPolynomial(poly).release(),
+                                  di.get_internal());
+  }
+  AlgebraicNumber::~AlgebraicNumber() {
+    lp_algebraic_number_destruct(get_internal());
+  }
+  AlgebraicNumber& AlgebraicNumber::operator=(const AlgebraicNumber& an) {
+    lp_algebraic_number_destruct(get_internal());
+    lp_algebraic_number_construct_copy(get_internal(), an.get_internal());
+    return *this;
+  }
+  AlgebraicNumber& AlgebraicNumber::operator=(AlgebraicNumber&& an) {
+    swap(*this, an);
+    return *this;
+  }
+
+  lp_algebraic_number_t* AlgebraicNumber::get_internal() { return &mValue; }
+  const lp_algebraic_number_t* AlgebraicNumber::get_internal() const {
+    return &mValue;
+  }
+
+  std::ostream& operator<<(std::ostream& os, const AlgebraicNumber& v) {
+    return os << lp_algebraic_number_to_string(v.get_internal());
+  }
+
+  void swap(AlgebraicNumber& lhs, AlgebraicNumber& rhs) {
+    lp_algebraic_number_swap(lhs.get_internal(), rhs.get_internal());
+  }
+  int sgn(const AlgebraicNumber& an) {
+    return lp_algebraic_number_sgn(an.get_internal());
+  }
+
+  bool operator==(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs) {
+    return lp_algebraic_number_cmp(lhs.get_internal(), rhs.get_internal()) == 0;
+  }
+  bool operator!=(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs) {
+    return lp_algebraic_number_cmp(lhs.get_internal(), rhs.get_internal()) != 0;
+  }
+  bool operator<(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs) {
+    return lp_algebraic_number_cmp(lhs.get_internal(), rhs.get_internal()) < 0;
+  }
+  bool operator<=(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs) {
+    return lp_algebraic_number_cmp(lhs.get_internal(), rhs.get_internal()) <= 0;
+  }
+  bool operator>(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs) {
+    return lp_algebraic_number_cmp(lhs.get_internal(), rhs.get_internal()) > 0;
+  }
+  bool operator>=(const AlgebraicNumber& lhs, const AlgebraicNumber& rhs) {
+    return lp_algebraic_number_cmp(lhs.get_internal(), rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const AlgebraicNumber& lhs, const Integer& rhs) {
+    return lp_algebraic_number_cmp_integer(lhs.get_internal(),
+                                           rhs.get_internal()) == 0;
+  }
+  bool operator!=(const AlgebraicNumber& lhs, const Integer& rhs) {
+    return lp_algebraic_number_cmp_integer(lhs.get_internal(),
+                                           rhs.get_internal()) != 0;
+  }
+  bool operator<(const AlgebraicNumber& lhs, const Integer& rhs) {
+    return lp_algebraic_number_cmp_integer(lhs.get_internal(),
+                                           rhs.get_internal()) < 0;
+  }
+  bool operator<=(const AlgebraicNumber& lhs, const Integer& rhs) {
+    return lp_algebraic_number_cmp_integer(lhs.get_internal(),
+                                           rhs.get_internal()) <= 0;
+  }
+  bool operator>(const AlgebraicNumber& lhs, const Integer& rhs) {
+    return lp_algebraic_number_cmp_integer(lhs.get_internal(),
+                                           rhs.get_internal()) > 0;
+  }
+  bool operator>=(const AlgebraicNumber& lhs, const Integer& rhs) {
+    return lp_algebraic_number_cmp_integer(lhs.get_internal(),
+                                           rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const Integer& lhs, const AlgebraicNumber& rhs) {
+    return rhs == lhs;
+  }
+  bool operator!=(const Integer& lhs, const AlgebraicNumber& rhs) {
+    return rhs != lhs;
+  }
+  bool operator<(const Integer& lhs, const AlgebraicNumber& rhs) {
+    return rhs > lhs;
+  }
+  bool operator<=(const Integer& lhs, const AlgebraicNumber& rhs) {
+    return rhs >= lhs;
+  }
+  bool operator>(const Integer& lhs, const AlgebraicNumber& rhs) {
+    return rhs < lhs;
+  }
+  bool operator>=(const Integer& lhs, const AlgebraicNumber& rhs) {
+    return rhs <= lhs;
+  }
+
+  bool operator==(const AlgebraicNumber& lhs, const DyadicRational& rhs) {
+    return lp_algebraic_number_cmp_dyadic_rational(lhs.get_internal(),
+                                                   rhs.get_internal()) == 0;
+  }
+  bool operator!=(const AlgebraicNumber& lhs, const DyadicRational& rhs) {
+    return lp_algebraic_number_cmp_dyadic_rational(lhs.get_internal(),
+                                                   rhs.get_internal()) != 0;
+  }
+  bool operator<(const AlgebraicNumber& lhs, const DyadicRational& rhs) {
+    return lp_algebraic_number_cmp_dyadic_rational(lhs.get_internal(),
+                                                   rhs.get_internal()) < 0;
+  }
+  bool operator<=(const AlgebraicNumber& lhs, const DyadicRational& rhs) {
+    return lp_algebraic_number_cmp_dyadic_rational(lhs.get_internal(),
+                                                   rhs.get_internal()) <= 0;
+  }
+  bool operator>(const AlgebraicNumber& lhs, const DyadicRational& rhs) {
+    return lp_algebraic_number_cmp_dyadic_rational(lhs.get_internal(),
+                                                   rhs.get_internal()) > 0;
+  }
+  bool operator>=(const AlgebraicNumber& lhs, const DyadicRational& rhs) {
+    return lp_algebraic_number_cmp_dyadic_rational(lhs.get_internal(),
+                                                   rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const DyadicRational& lhs, const AlgebraicNumber& rhs) {
+    return rhs == lhs;
+  }
+  bool operator!=(const DyadicRational& lhs, const AlgebraicNumber& rhs) {
+    return rhs != lhs;
+  }
+  bool operator<(const DyadicRational& lhs, const AlgebraicNumber& rhs) {
+    return rhs > lhs;
+  }
+  bool operator<=(const DyadicRational& lhs, const AlgebraicNumber& rhs) {
+    return rhs >= lhs;
+  }
+  bool operator>(const DyadicRational& lhs, const AlgebraicNumber& rhs) {
+    return rhs < lhs;
+  }
+  bool operator>=(const DyadicRational& lhs, const AlgebraicNumber& rhs) {
+    return rhs <= lhs;
+  }
+
+  bool operator==(const AlgebraicNumber& lhs, const Rational& rhs) {
+    return lp_algebraic_number_cmp_rational(lhs.get_internal(),
+                                            rhs.get_internal()) == 0;
+  }
+  bool operator!=(const AlgebraicNumber& lhs, const Rational& rhs) {
+    return lp_algebraic_number_cmp_rational(lhs.get_internal(),
+                                            rhs.get_internal()) != 0;
+  }
+  bool operator<(const AlgebraicNumber& lhs, const Rational& rhs) {
+    return lp_algebraic_number_cmp_rational(lhs.get_internal(),
+                                            rhs.get_internal()) < 0;
+  }
+  bool operator<=(const AlgebraicNumber& lhs, const Rational& rhs) {
+    return lp_algebraic_number_cmp_rational(lhs.get_internal(),
+                                            rhs.get_internal()) <= 0;
+  }
+  bool operator>(const AlgebraicNumber& lhs, const Rational& rhs) {
+    return lp_algebraic_number_cmp_rational(lhs.get_internal(),
+                                            rhs.get_internal()) > 0;
+  }
+  bool operator>=(const AlgebraicNumber& lhs, const Rational& rhs) {
+    return lp_algebraic_number_cmp_rational(lhs.get_internal(),
+                                            rhs.get_internal()) >= 0;
+  }
+
+  bool operator==(const Rational& lhs, const AlgebraicNumber& rhs) {
+    return rhs == lhs;
+  }
+  bool operator!=(const Rational& lhs, const AlgebraicNumber& rhs) {
+    return rhs != lhs;
+  }
+  bool operator<(const Rational& lhs, const AlgebraicNumber& rhs) {
+    return rhs > lhs;
+  }
+  bool operator<=(const Rational& lhs, const AlgebraicNumber& rhs) {
+    return rhs >= lhs;
+  }
+  bool operator>(const Rational& lhs, const AlgebraicNumber& rhs) {
+    return rhs < lhs;
+  }
+  bool operator>=(const Rational& lhs, const AlgebraicNumber& rhs) {
+    return rhs <= lhs;
+  }
+
+  double to_double(const AlgebraicNumber& an) {
+    return lp_algebraic_number_to_double(an.get_internal());
+  }
+
+  Rational to_rational_approximation(const AlgebraicNumber& an) {
+    Rational res;
+    lp_algebraic_number_to_rational(an.get_internal(), res.get_internal());
+    return res;
+  }
+
+  const DyadicRational& get_lower_bound(const AlgebraicNumber& an) {
+    return get_lower(*detail::cast_from(&an.get_internal()->I));
+  }
+  const DyadicRational& get_upper_bound(const AlgebraicNumber& an) {
+    return get_upper(*detail::cast_from(&an.get_internal()->I));
+  }
+
+  DyadicRational midpoint_dyadic(const AlgebraicNumber& an) {
+    DyadicRational res;
+    lp_algebraic_number_get_dyadic_midpoint(an.get_internal(),
+                                            res.get_internal());
+    return res;
+  }
+  Rational midpoint_rational(const AlgebraicNumber& an) {
+    Rational res;
+    lp_algebraic_number_get_rational_midpoint(an.get_internal(),
+                                              res.get_internal());
+    return res;
+  }
+  void refine(AlgebraicNumber& an) {
+    lp_algebraic_number_refine(an.get_internal());
+  }
+  void refine_const(const AlgebraicNumber& an) {
+    lp_algebraic_number_refine_const(an.get_internal());
+  }
+
+  AlgebraicNumber operator+(const AlgebraicNumber& lhs,
+                            const AlgebraicNumber& rhs) {
+    AlgebraicNumber res;
+    lp_algebraic_number_add(res.get_internal(), lhs.get_internal(),
+                            rhs.get_internal());
+    return res;
+  }
+  AlgebraicNumber operator-(const AlgebraicNumber& lhs,
+                            const AlgebraicNumber& rhs) {
+    AlgebraicNumber res;
+    lp_algebraic_number_sub(res.get_internal(), lhs.get_internal(),
+                            rhs.get_internal());
+    return res;
+  }
+
+  AlgebraicNumber operator-(const AlgebraicNumber& an) {
+    AlgebraicNumber res;
+    lp_algebraic_number_neg(res.get_internal(), an.get_internal());
+    return res;
+  }
+  AlgebraicNumber operator*(const AlgebraicNumber& lhs,
+                            const AlgebraicNumber& rhs) {
+    AlgebraicNumber res;
+    lp_algebraic_number_mul(res.get_internal(), lhs.get_internal(),
+                            rhs.get_internal());
+    return res;
+  }
+  AlgebraicNumber pow(const AlgebraicNumber& lhs, unsigned n) {
+    AlgebraicNumber res;
+    lp_algebraic_number_pow(res.get_internal(), lhs.get_internal(), n);
+    return res;
+  }
+
+  bool is_rational(const AlgebraicNumber& an) {
+    return lp_algebraic_number_is_rational(an.get_internal());
+  }
+  bool is_integer(const AlgebraicNumber& an) {
+    return lp_algebraic_number_is_integer(an.get_internal());
+  }
+  bool is_zero(const AlgebraicNumber& an) { return an == AlgebraicNumber(); }
+  bool is_one(const AlgebraicNumber& an) {
+    return an == AlgebraicNumber(DyadicRational(1));
+  }
+
+  Integer ceil(const AlgebraicNumber& an) {
+    Integer res;
+    lp_algebraic_number_ceiling(an.get_internal(), res.get_internal());
+    return res;
+  }
+  Integer floor(const AlgebraicNumber& an) {
+    Integer res;
+    lp_algebraic_number_floor(an.get_internal(), res.get_internal());
+    return res;
+  }
+
+}  // namespace poly

--- a/src/polyxx/upolynomial.cpp
+++ b/src/polyxx/upolynomial.cpp
@@ -1,0 +1,322 @@
+#include "polyxx/upolynomial.h"
+
+#include "upolynomial_factors.h"
+
+namespace poly {
+
+  /** A deleter for an std::unique_ptr holding a lp_upolynomial_t pointer */
+  inline void upolynomial_deleter(lp_upolynomial_t* ptr) {
+    lp_upolynomial_delete(ptr);
+  }
+
+  UPolynomial::UPolynomial(lp_upolynomial_t* poly)
+      : mPoly(poly, upolynomial_deleter) {}
+  UPolynomial::UPolynomial(const lp_upolynomial_t* poly)
+      : mPoly(lp_upolynomial_construct_copy(poly), upolynomial_deleter) {}
+
+  UPolynomial::UPolynomial()
+      : mPoly(lp_upolynomial_construct_power(lp_Z, 0, 0), upolynomial_deleter) {
+  }
+  UPolynomial::UPolynomial(const Integer& i)
+      : mPoly(lp_upolynomial_construct(lp_Z, 0, i.get_internal()),
+              upolynomial_deleter) {}
+  UPolynomial::UPolynomial(long i)
+      : mPoly(lp_upolynomial_construct_power(lp_Z, 0, i), upolynomial_deleter) {
+  }
+
+  UPolynomial::UPolynomial(const std::vector<Integer>& coefficients)
+      : UPolynomial(IntegerRing::Z, coefficients) {}
+  UPolynomial::UPolynomial(const IntegerRing& ir,
+                           const std::vector<Integer>& coefficients)
+      : mPoly(
+            lp_upolynomial_construct(ir.get_internal(), coefficients.size() - 1,
+                                     detail::cast_to(coefficients.data())),
+            upolynomial_deleter) {}
+  UPolynomial::UPolynomial(const std::vector<long>& coefficients)
+      : UPolynomial(IntegerRing::Z, coefficients) {}
+  UPolynomial::UPolynomial(const IntegerRing& ir,
+                           const std::vector<long>& coefficients)
+      : mPoly(lp_upolynomial_construct_from_long(ir.get_internal(),
+                                                 coefficients.size() - 1,
+                                                 coefficients.data()),
+              upolynomial_deleter) {}
+
+  UPolynomial::UPolynomial(std::initializer_list<long> coefficients)
+      : UPolynomial(std::vector<long>(coefficients)) {}
+  UPolynomial::UPolynomial(const IntegerRing& ir,
+                           std::initializer_list<long> coefficients)
+      : UPolynomial(ir, std::vector<long>(coefficients)) {}
+
+  UPolynomial::UPolynomial(std::size_t degree, long c)
+      : UPolynomial(IntegerRing::Z, degree, c) {}
+
+  UPolynomial::UPolynomial(const IntegerRing& ir, std::size_t degree, long c)
+      : mPoly(lp_upolynomial_construct_power(ir.get_internal(), degree, c),
+              upolynomial_deleter) {}
+
+  UPolynomial::UPolynomial(const UPolynomial& poly)
+      : mPoly(lp_upolynomial_construct_copy(poly.get_internal()),
+              upolynomial_deleter) {}
+
+  UPolynomial::UPolynomial(UPolynomial&& poly)
+      : mPoly(poly.release(), upolynomial_deleter) {}
+
+  UPolynomial::UPolynomial(const IntegerRing& ir, const UPolynomial& poly)
+      : mPoly(lp_upolynomial_construct_copy_K(ir.get_internal(),
+                                              poly.get_internal()),
+              upolynomial_deleter) {}
+
+  UPolynomial& UPolynomial::operator=(const UPolynomial& poly) {
+    mPoly.reset(lp_upolynomial_construct_copy(poly.get_internal()));
+    return *this;
+  }
+  UPolynomial& UPolynomial::operator=(UPolynomial&& poly) {
+    mPoly.reset(lp_upolynomial_construct_copy(poly.get_internal()));
+    return *this;
+  }
+  UPolynomial& UPolynomial::operator=(lp_upolynomial_t* poly) {
+    mPoly.reset(poly);
+    return *this;
+  }
+
+  lp_upolynomial_t* UPolynomial::get_internal() { return mPoly.get(); }
+  const lp_upolynomial_t* UPolynomial::get_internal() const {
+    return mPoly.get();
+  }
+  lp_upolynomial_t* UPolynomial::release() { return mPoly.release(); }
+
+  std::size_t degree(const UPolynomial& p) {
+    return lp_upolynomial_degree(p.get_internal());
+  }
+
+  const Integer& leading_coefficient(const UPolynomial& p) {
+    return *detail::cast_from(lp_upolynomial_lead_coeff(p.get_internal()));
+  }
+  const Integer& constant_coefficient(const UPolynomial& p) {
+    return *detail::cast_from(lp_upolynomial_const_term(p.get_internal()));
+  }
+
+  std::vector<Integer> coefficients(const UPolynomial& p) {
+    lp_integer_t coeffs[degree(p) + 1];
+    for (std::size_t i = 0; i < degree(p) + 1; ++i) {
+      lp_integer_construct_from_int(lp_Z, &coeffs[i], 0);
+    }
+    lp_upolynomial_unpack(p.get_internal(), coeffs);
+    std::vector<Integer> res;
+    for (std::size_t i = 0; i < degree(p) + 1; ++i) {
+      res.emplace_back(&coeffs[i]);
+      lp_integer_destruct(&coeffs[i]);
+    }
+    return res;
+  }
+
+  std::ostream& operator<<(std::ostream& os, const UPolynomial& p) {
+    return os << lp_upolynomial_to_string(p.get_internal());
+  }
+
+  bool is_zero(const UPolynomial& p) {
+    return lp_upolynomial_is_zero(p.get_internal());
+  }
+  bool is_one(const UPolynomial& p) {
+    return lp_upolynomial_is_one(p.get_internal());
+  }
+  bool is_monic(const UPolynomial& p) {
+    return lp_upolynomial_is_monic(p.get_internal());
+  }
+  bool is_primitive(const UPolynomial& p) {
+    return lp_upolynomial_is_primitive(p.get_internal());
+  }
+
+  Integer evaluate_at(const UPolynomial& p, const Integer& i) {
+    Integer res;
+    lp_upolynomial_evaluate_at_integer(p.get_internal(), i.get_internal(),
+                                       res.get_internal());
+    return res;
+  }
+  Rational evaluate_at(const UPolynomial& p, const Rational& r) {
+    Rational res;
+    lp_upolynomial_evaluate_at_rational(p.get_internal(), r.get_internal(),
+                                        res.get_internal());
+    return res;
+  }
+  DyadicRational evaluate_at(const UPolynomial& p, const DyadicRational& dr) {
+    DyadicRational res;
+    lp_upolynomial_evaluate_at_dyadic_rational(
+        p.get_internal(), dr.get_internal(), res.get_internal());
+    return res;
+  }
+
+  int sign_at(const UPolynomial& p, const Integer& i) {
+    return lp_upolynomial_sgn_at_integer(p.get_internal(), i.get_internal());
+  }
+  int sign_at(const UPolynomial& p, const Rational& r) {
+    return lp_upolynomial_sgn_at_rational(p.get_internal(), r.get_internal());
+  }
+  int sign_at(const UPolynomial& p, const DyadicRational& dr) {
+    return lp_upolynomial_sgn_at_dyadic_rational(p.get_internal(),
+                                                 dr.get_internal());
+  }
+
+  bool operator==(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return lp_upolynomial_cmp(lhs.get_internal(), rhs.get_internal()) == 0;
+  }
+  bool operator!=(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return lp_upolynomial_cmp(lhs.get_internal(), rhs.get_internal()) != 0;
+  }
+  bool operator<(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return lp_upolynomial_cmp(lhs.get_internal(), rhs.get_internal()) < 0;
+  }
+  bool operator<=(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return lp_upolynomial_cmp(lhs.get_internal(), rhs.get_internal()) <= 0;
+  }
+  bool operator>(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return lp_upolynomial_cmp(lhs.get_internal(), rhs.get_internal()) > 0;
+  }
+  bool operator>=(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return lp_upolynomial_cmp(lhs.get_internal(), rhs.get_internal()) >= 0;
+  }
+
+  UPolynomial subst_x_neg(const UPolynomial& p) {
+    return UPolynomial(lp_upolynomial_subst_x_neg(p.get_internal()));
+  }
+  UPolynomial operator-(const UPolynomial& p) {
+    return UPolynomial(lp_upolynomial_neg(p.get_internal()));
+  }
+  void neg(UPolynomial& p) { lp_upolynomial_neg_in_place(p.get_internal()); }
+
+  UPolynomial operator+(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return UPolynomial(
+        lp_upolynomial_add(lhs.get_internal(), rhs.get_internal()));
+  }
+  UPolynomial operator-(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return UPolynomial(
+        lp_upolynomial_sub(lhs.get_internal(), rhs.get_internal()));
+  }
+  UPolynomial operator*(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return UPolynomial(
+        lp_upolynomial_mul(lhs.get_internal(), rhs.get_internal()));
+  }
+  UPolynomial operator*(const UPolynomial& lhs, const Integer& rhs) {
+    return UPolynomial(
+        lp_upolynomial_mul_c(lhs.get_internal(), rhs.get_internal()));
+  }
+  UPolynomial operator*(const Integer& lhs, const UPolynomial& rhs) {
+    return UPolynomial(
+        lp_upolynomial_mul_c(rhs.get_internal(), lhs.get_internal()));
+  }
+
+  UPolynomial pow(const UPolynomial& lhs, long rhs) {
+    return UPolynomial(lp_upolynomial_pow(lhs.get_internal(), rhs));
+  }
+
+  UPolynomial derivative(const UPolynomial& p) {
+    return UPolynomial(lp_upolynomial_derivative(p.get_internal()));
+  }
+
+  bool divides(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return lp_upolynomial_divides(lhs.get_internal(), rhs.get_internal());
+  }
+
+  UPolynomial div_degrees(const UPolynomial& lhs, long rhs) {
+    return UPolynomial(lp_upolynomial_div_degrees(lhs.get_internal(), rhs));
+  }
+
+  UPolynomial div_exact(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return UPolynomial(
+        lp_upolynomial_div_exact(lhs.get_internal(), rhs.get_internal()));
+  }
+  UPolynomial div_exact(const UPolynomial& lhs, const Integer& rhs) {
+    return UPolynomial(
+        lp_upolynomial_div_exact_c(lhs.get_internal(), rhs.get_internal()));
+  }
+  UPolynomial rem_exact(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return UPolynomial(
+        lp_upolynomial_rem_exact(lhs.get_internal(), rhs.get_internal()));
+  }
+  std::pair<UPolynomial, UPolynomial> div_rem_exact(const UPolynomial& lhs,
+                                                    const UPolynomial& rhs) {
+    lp_upolynomial_t* div = nullptr;
+    lp_upolynomial_t* rem = nullptr;
+    lp_upolynomial_div_rem_exact(lhs.get_internal(), rhs.get_internal(), &div,
+                                 &rem);
+    return {UPolynomial(div), UPolynomial(rem)};
+  }
+  std::pair<UPolynomial, UPolynomial> div_rem_pseudo(const UPolynomial& lhs,
+                                                     const UPolynomial& rhs) {
+    lp_upolynomial_t* div = nullptr;
+    lp_upolynomial_t* rem = nullptr;
+    lp_upolynomial_div_pseudo(&div, &rem, lhs.get_internal(),
+                              rhs.get_internal());
+    return {UPolynomial(div), UPolynomial(rem)};
+  }
+
+  Integer content(const UPolynomial& p) {
+    Integer res;
+    lp_upolynomial_content_Z(p.get_internal(), res.get_internal());
+    return res;
+  }
+  void make_primitive(UPolynomial& p) {
+    lp_upolynomial_make_primitive_Z(p.get_internal());
+  }
+  UPolynomial primitive_part(const UPolynomial& p) {
+    return UPolynomial(lp_upolynomial_primitive_part_Z(p.get_internal()));
+  }
+
+  UPolynomial gcd(const UPolynomial& lhs, const UPolynomial& rhs) {
+    return UPolynomial(
+        lp_upolynomial_gcd(lhs.get_internal(), rhs.get_internal()));
+  }
+  UPolynomial extended_gcd(const UPolynomial& lhs, const UPolynomial& rhs,
+                           UPolynomial& u, UPolynomial& v) {
+    lp_upolynomial_t* up = nullptr;
+    lp_upolynomial_t* vp = nullptr;
+    UPolynomial res(lp_upolynomial_extended_gcd(lhs.get_internal(),
+                                                rhs.get_internal(), &up, &vp));
+    u = up;
+    v = vp;
+    return res;
+  }
+
+  void solve_bezout(const UPolynomial& p, const UPolynomial& q,
+                    const UPolynomial& r, UPolynomial& u, UPolynomial& v) {
+    lp_upolynomial_t* up = nullptr;
+    lp_upolynomial_t* vp = nullptr;
+    lp_upolynomial_solve_bezout(p.get_internal(), q.get_internal(),
+                                r.get_internal(), &up, &vp);
+    u = up;
+    v = vp;
+  }
+
+  std::vector<UPolynomial> square_free_factors(const UPolynomial& p,
+                                               bool with_constant) {
+    auto factors = lp_upolynomial_factor_square_free(p.get_internal());
+    std::vector<UPolynomial> res;
+
+    if (with_constant) {
+      res.emplace_back(std::vector<Integer>(
+          {Integer(lp_upolynomial_factors_get_constant(factors))}));
+    }
+
+    for (std::size_t i = 0; i < lp_upolynomial_factors_size(factors); ++i) {
+      std::size_t multiplicity = 0;
+      res.emplace_back(
+          lp_upolynomial_factors_get_factor(factors, i, &multiplicity));
+    }
+
+    lp_upolynomial_factors_destruct(factors, 0);
+    return res;
+  }
+
+  std::vector<UPolynomial> sturm_sequence(const UPolynomial& p) {
+    lp_upolynomial_t** seq;
+    std::size_t size;
+    lp_upolynomial_sturm_sequence(p.get_internal(), &seq, &size);
+    std::vector<UPolynomial> res;
+    for (std::size_t i = 0; i < size; ++i) {
+      res.emplace_back(seq[i]);
+    }
+    free(seq);
+    return res;
+  }
+
+}  // namespace poly

--- a/test/polyxx/CMakeLists.txt
+++ b/test/polyxx/CMakeLists.txt
@@ -1,8 +1,10 @@
 set(polyxx_tests
+    test_algebraic_number
     test_dyadic_interval
     test_dyadic_rational
     test_integer
     test_rational
+    test_upolynomial
     test_variable
 )
 

--- a/test/polyxx/test_algebraic_number.cpp
+++ b/test/polyxx/test_algebraic_number.cpp
@@ -1,0 +1,77 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <polyxx.h>
+
+#include "doctest.h"
+
+using namespace poly;
+
+TEST_CASE("algebraic_number::move") {
+  AlgebraicNumber a(UPolynomial({-2, 0, 1}), DyadicInterval(-2, -1));
+  AlgebraicNumber a2(std::move(a));
+}
+
+TEST_CASE("algebraic_number::swap") {
+  AlgebraicNumber a(UPolynomial({-2, 0, 1}), DyadicInterval(-2, -1));
+  AlgebraicNumber b(UPolynomial({-2, 0, 1}), DyadicInterval(1, 2));
+  swap(a, b);
+  CHECK(a == AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(1, 2)));
+  CHECK(b == AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(-2, -1)));
+}
+
+TEST_CASE("algebraic_number::sgn") {
+  CHECK(sgn(AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(-2, -1))) ==
+        -1);
+  CHECK(sgn(AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(1, 2))) ==
+        1);
+}
+
+TEST_CASE("algebraic_number::to_double") {
+  double d1 = to_double(
+      AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(-2, -1)));
+  CHECK(-1.5 < d1);
+  CHECK(d1 < -1.4);
+  double d2 =
+      to_double(AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(1, 2)));
+  CHECK(1.4 < d2);
+  CHECK(d2 < 1.5);
+}
+TEST_CASE("algebraic_number::to_rational_approximation") {
+  Rational r1 = to_rational_approximation(
+      AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(-2, -1)));
+  CHECK(Rational(-2) < r1);
+  CHECK(r1 < Rational(-1));
+  Rational r2 = to_rational_approximation(
+      AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(1, 2)));
+  CHECK(Rational(1) < r2);
+  CHECK(r2 < Rational(2));
+}
+
+TEST_CASE("algebraic_number::is_rational") {
+  CHECK_FALSE(is_rational(
+      AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(-2, -1))));
+  CHECK(
+      is_rational(AlgebraicNumber(UPolynomial({1, 3}), DyadicInterval(-2, 0))));
+  CHECK(is_rational(
+      AlgebraicNumber(UPolynomial({3, 1}), DyadicInterval(-4, -2))));
+}
+TEST_CASE("algebraic_number::is_integer") {
+  CHECK_FALSE(is_integer(
+      AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(-2, -1))));
+  CHECK_FALSE(
+      is_integer(AlgebraicNumber(UPolynomial({1, 3}), DyadicInterval(-2, 0))));
+  CHECK(
+      is_integer(AlgebraicNumber(UPolynomial({3, 1}), DyadicInterval(-4, -2))));
+}
+
+TEST_CASE("algebraic_number::ceil") {
+  CHECK(ceil(AlgebraicNumber(UPolynomial({-2, 0, 1}),
+                             DyadicInterval(-2, -1))) == Integer(-1));
+  CHECK(ceil(AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(1, 2))) ==
+        Integer(2));
+}
+TEST_CASE("algebraic_number::floor") {
+  CHECK(floor(AlgebraicNumber(UPolynomial({-2, 0, 1}),
+                              DyadicInterval(-2, -1))) == Integer(-2));
+  CHECK(floor(AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(1, 2))) ==
+        Integer(1));
+}

--- a/test/polyxx/test_upolynomial.cpp
+++ b/test/polyxx/test_upolynomial.cpp
@@ -1,0 +1,240 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <polyxx.h>
+
+#include "doctest.h"
+
+using namespace poly;
+
+TEST_CASE("upolynomial::degree") {
+  CHECK(degree(UPolynomial()) == 0);
+  CHECK(degree(UPolynomial({1})) == 0);
+  CHECK(degree(UPolynomial({1, 1})) == 1);
+  CHECK(degree(UPolynomial({-2, 0, 1})) == 2);
+}
+
+TEST_CASE("upolynomial::leading_coefficient") {
+  CHECK(leading_coefficient(UPolynomial()) == Integer(0));
+  CHECK(leading_coefficient(UPolynomial({1})) == Integer(1));
+  CHECK(leading_coefficient(UPolynomial({1, 2})) == Integer(2));
+  CHECK(leading_coefficient(UPolynomial({-2, 0, 3})) == Integer(3));
+}
+
+TEST_CASE("upolynomial::constant_coefficient") {
+  CHECK(constant_coefficient(UPolynomial()) == Integer(0));
+  CHECK(constant_coefficient(UPolynomial({1})) == Integer(1));
+  CHECK(constant_coefficient(UPolynomial({2, 2})) == Integer(2));
+  CHECK(constant_coefficient(UPolynomial({2, 0, 3})) == Integer(2));
+}
+
+TEST_CASE("upolynomial::constant_coefficient") {
+  CHECK(coefficients(UPolynomial()) == std::vector<Integer>({Integer(0)}));
+  CHECK(coefficients(UPolynomial({1})) == std::vector<Integer>({Integer(1)}));
+  CHECK(coefficients(UPolynomial({2, 2})) ==
+        std::vector<Integer>({Integer(2), Integer(2)}));
+  CHECK(coefficients(UPolynomial({2, 0, 3})) ==
+        std::vector<Integer>({Integer(2), Integer(), Integer(3)}));
+}
+
+TEST_CASE("upolynomial::is_zero") {
+  CHECK(is_zero(UPolynomial()));
+  CHECK_FALSE(is_zero(UPolynomial({-1})));
+  CHECK(is_zero(UPolynomial({0})));
+  CHECK_FALSE(is_zero(UPolynomial({1})));
+  CHECK_FALSE(is_zero(UPolynomial({2, 2})));
+  CHECK_FALSE(is_zero(UPolynomial({0, 2})));
+}
+
+TEST_CASE("upolynomial::is_one") {
+  CHECK_FALSE(is_one(UPolynomial()));
+  CHECK_FALSE(is_one(UPolynomial({-1})));
+  CHECK_FALSE(is_one(UPolynomial({0})));
+  CHECK(is_one(UPolynomial({1})));
+  CHECK_FALSE(is_one(UPolynomial({2, 2})));
+  CHECK_FALSE(is_one(UPolynomial({0, 2})));
+}
+
+TEST_CASE("upolynomial::is_monic") {
+  CHECK_FALSE(is_monic(UPolynomial()));
+  CHECK_FALSE(is_monic(UPolynomial({-1})));
+  CHECK_FALSE(is_monic(UPolynomial({0})));
+  CHECK(is_monic(UPolynomial({1})));
+  CHECK(is_monic(UPolynomial({0, 1})));
+  CHECK_FALSE(is_monic(UPolynomial({0, 2})));
+  CHECK(is_monic(UPolynomial({1, 1})));
+  CHECK_FALSE(is_monic(UPolynomial({1, 2})));
+  CHECK(is_monic(UPolynomial({2, 1})));
+  CHECK_FALSE(is_monic(UPolynomial({2, 2})));
+}
+
+TEST_CASE("upolynomial::is_primitive") {
+  CHECK_FALSE(is_primitive(UPolynomial({-1})));
+  CHECK(is_primitive(UPolynomial({1})));
+  CHECK(is_primitive(UPolynomial({0, 1})));
+  CHECK_FALSE(is_primitive(UPolynomial({0, 2})));
+  CHECK(is_primitive(UPolynomial({1, 1})));
+  CHECK(is_primitive(UPolynomial({1, 2})));
+  CHECK(is_primitive(UPolynomial({2, 1})));
+  CHECK_FALSE(is_primitive(UPolynomial({2, 2})));
+}
+
+TEST_CASE("upolynomial::evaluate_at") {
+  UPolynomial p({1, 1, 1});
+  CHECK(evaluate_at(p, Integer(-1)) == Integer(1));
+  CHECK(evaluate_at(p, Integer()) == Integer(1));
+  CHECK(evaluate_at(p, Integer(1)) == Integer(3));
+  CHECK(evaluate_at(p, Integer(2)) == Integer(7));
+
+  CHECK(evaluate_at(p, Rational(-1, 2)) == Rational(3, 4));
+  CHECK(evaluate_at(p, Rational()) == Rational(1));
+  CHECK(evaluate_at(p, Rational(1, 3)) == Rational(13, 9));
+  CHECK(evaluate_at(p, Rational(2, 3)) == Rational(19, 9));
+
+  CHECK(evaluate_at(p, DyadicRational(-1, 1)) == DyadicRational(3, 2));
+  CHECK(evaluate_at(p, DyadicRational()) == DyadicRational(1));
+  CHECK(evaluate_at(p, DyadicRational(1, 2)) == DyadicRational(21, 4));
+  CHECK(evaluate_at(p, DyadicRational(1, 3)) == DyadicRational(73, 6));
+}
+
+TEST_CASE("upolynomial::sign_at") {
+  UPolynomial p({2, 1, -1});
+  CHECK(sign_at(p, Integer(-2)) == -1);
+  CHECK(sign_at(p, Integer(-1)) == 0);
+  CHECK(sign_at(p, Integer()) == 1);
+  CHECK(sign_at(p, Integer(1)) == 1);
+  CHECK(sign_at(p, Integer(2)) == 0);
+
+  CHECK(sign_at(p, Rational(-5, 2)) == -1);
+  CHECK(sign_at(p, Rational(-1)) == 0);
+  CHECK(sign_at(p, Rational(-1, 2)) == 1);
+  CHECK(sign_at(p, Rational(2)) == 0);
+  CHECK(sign_at(p, Rational(7, 3)) == -1);
+
+  CHECK(sign_at(p, DyadicRational(-13, 2)) == -1);
+  CHECK(sign_at(p, DyadicRational(-8, 3)) == 0);
+  CHECK(sign_at(p, DyadicRational(-1, 5)) == 1);
+  CHECK(sign_at(p, DyadicRational(8, 2)) == 0);
+  CHECK(sign_at(p, DyadicRational(71, 3)) == -1);
+}
+
+TEST_CASE("upolynomial::subst_x_neg") {
+  CHECK(subst_x_neg(UPolynomial({2, 1, -1})) == UPolynomial({2, -1, -1}));
+}
+
+TEST_CASE("upolynomial::operator-") {
+  CHECK(-UPolynomial({2, 1, -1}) == UPolynomial({-2, -1, 1}));
+}
+
+TEST_CASE("upolynomial::neg") {
+  UPolynomial p({2, 1, -1});
+  neg(p);
+  CHECK(p == UPolynomial({-2, -1, 1}));
+}
+
+TEST_CASE("upolynomial::operator+") {
+  CHECK(UPolynomial({2, 1, -1}) + UPolynomial({1, 2, 3}) ==
+        UPolynomial({3, 3, 2}));
+}
+TEST_CASE("upolynomial::operator-") {
+  CHECK(UPolynomial({2, 1, -1}) - UPolynomial({1, 2, 3}) ==
+        UPolynomial({1, -1, -4}));
+}
+TEST_CASE("upolynomial::operator*") {
+  CHECK(UPolynomial({2, 1, -1}) * UPolynomial({1, 2, 3}) ==
+        UPolynomial({2, 5, 7, 1, -3}));
+  CHECK(UPolynomial({2, 1, -1}) * Integer(3) == UPolynomial({6, 3, -3}));
+  CHECK(Integer(3) * UPolynomial({2, 1, -1}) == UPolynomial({6, 3, -3}));
+}
+
+TEST_CASE("upolynomial::pow") {
+  CHECK(pow(UPolynomial({2, 1, -1}), 3) ==
+        UPolynomial({8, 12, -6, -11, 3, 3, -1}));
+}
+
+TEST_CASE("upolynomial::derivative") {
+  CHECK(derivative(UPolynomial({2, 5, 7, 1, -3})) ==
+        UPolynomial({5, 14, 3, -12}));
+}
+
+TEST_CASE("upolynomial::divides") {
+  CHECK(divides(UPolynomial({2, 1, -1}), UPolynomial({2, 5, 7, 1, -3})));
+  CHECK(divides(UPolynomial({1, 2, 3}), UPolynomial({2, 5, 7, 1, -3})));
+}
+
+TEST_CASE("upolynomial::div_degrees") {
+  CHECK(div_degrees(UPolynomial({1, 0, 0, 2, 0, 0, 3}), 3) ==
+        UPolynomial({1, 2, 3}));
+}
+
+TEST_CASE("upolynomial::div_exact") {
+  CHECK(div_exact(UPolynomial({2, 5, 7, 1, -3}), UPolynomial({2, 1, -1})) ==
+        UPolynomial({1, 2, 3}));
+  CHECK(div_exact(UPolynomial({2, 5, 7, 1, -3}), UPolynomial({1, 2, 3})) ==
+        UPolynomial({2, 1, -1}));
+}
+
+TEST_CASE("upolynomial::div_exact") {
+  CHECK(div_exact(UPolynomial({2, 4, 6, 8}), Integer(2)) ==
+        UPolynomial({1, 2, 3, 4}));
+}
+
+TEST_CASE("upolynomial::rem_exact") {
+  CHECK(rem_exact(UPolynomial({2, 5, 7, 1, -3}), UPolynomial({3, 0, -1, 1})) ==
+        UPolynomial({8, 14, 5}));
+}
+
+TEST_CASE("upolynomial::div_rem_exact") {
+  auto res =
+      div_rem_exact(UPolynomial({2, 5, 7, 1, -3}), UPolynomial({3, 0, -1, 1}));
+  CHECK(res.first == UPolynomial({-2, -3}));
+  CHECK(res.second == UPolynomial({8, 14, 5}));
+}
+
+TEST_CASE("upolynomial::div_rem_pseudo") {
+  auto res =
+      div_rem_pseudo(UPolynomial({2, 5, 7, 1, -3}), UPolynomial({3, 0, -1, 1}));
+  CHECK(res.first == UPolynomial({-2, -3}));
+  CHECK(res.second == UPolynomial({8, 14, 5}));
+}
+
+TEST_CASE("upolynomial::content") {
+  CHECK(content(UPolynomial({12, 18, 24})) == Integer(6));
+}
+
+TEST_CASE("upolynomial::make_primitive") {
+  UPolynomial p({12, 18, 24});
+  make_primitive(p);
+  CHECK(p == UPolynomial({2, 3, 4}));
+}
+
+TEST_CASE("upolynomial::primitive_part") {
+  CHECK(primitive_part(UPolynomial({12, 18, 24})) == UPolynomial({2, 3, 4}));
+}
+
+TEST_CASE("upolynomial::gcd") {
+  UPolynomial p({1, 2, 3, 4, 5});
+  UPolynomial q({3, 4, 1});
+  UPolynomial r({-3, 7, -9});
+  CHECK(gcd(p * q, q * r) == q);
+  CHECK(gcd(p * q, p * r) == p);
+  CHECK(gcd(p * r, r * r) == -r);
+}
+
+TEST_CASE("upolynomial::square_free_factors") {
+  UPolynomial p({1, 2, 3, 4, 5});
+  auto factors = square_free_factors(p, true);
+  UPolynomial prod(Integer(1));
+  for (const auto& f : factors) {
+    prod = f * prod;
+  }
+  CHECK(prod == p);
+}
+
+TEST_CASE("upolynomial::sturm_sequence") {
+  auto seq = sturm_sequence(UPolynomial({2, 5, 7, 1, -3}));
+  CHECK(seq.size() == 5);
+  CHECK(seq[0] == UPolynomial({-2, -5, -7, -1, 3}));
+  CHECK(seq[1] == UPolynomial({-5, -14, -3, 12}));
+  CHECK(seq[2] == UPolynomial({101, 194, 171}));
+  CHECK(seq[3] == UPolynomial({-733, 341}));
+  CHECK(seq[4] == UPolynomial({-1}));
+}


### PR DESCRIPTION
The PR adds new wrapper classes for `lp_upolynomial_t` (`UPolynomial`) and `lp_algebraic_number_t` (`AlgebraicNumber`). As for `Integer`, usage of `UPolynomial` with a custom integer ring should be reasonably comfortable.
`UPolynomial` follows the C++ api and holds the `lp_upolynomial_t` instance as a pointer (`std::unique_ptr`), and thus allows for efficient move operations.
`AlgebraicNumber` on the other hand holds the `lp_algebraic_number_t` as its only member (much like `Integer` and `Rational`) and thus allows for easy casting to and from `lp_algebraic_number_t`.
Most of the C interface is exported in the C++ interface as well and unit tests are added.