### PR TITLE
Handle none as a special lower-than-everything-else value in value comparison

### DIFF
--- a/src/number/value.c
+++ b/src/number/value.c
@@ -280,12 +280,7 @@ int lp_value_cmp(const lp_value_t* v1, const lp_value_t* v2) {
   }
 
   // Different types
-  if (v1->type == LP_VALUE_NONE) {
-    return -1;
-  }
-  if (v2->type == LP_VALUE_NONE) {
-    return 1;
-  }
+  assert(v1->type != LP_VALUE_NONE && v2->type != LP_VALUE_NONE);
   if (v1->type == LP_VALUE_MINUS_INFINITY) {
     return -1;
   }

--- a/src/number/value.c
+++ b/src/number/value.c
@@ -280,7 +280,12 @@ int lp_value_cmp(const lp_value_t* v1, const lp_value_t* v2) {
   }
 
   // Different types
-
+  if (v1->type == LP_VALUE_NONE) {
+    return -1;
+  }
+  if (v2->type == LP_VALUE_NONE) {
+    return 1;
+  }
   if (v1->type == LP_VALUE_MINUS_INFINITY) {
     return -1;
   }


### PR DESCRIPTION
Right now, `LP_VALUE_NONE` is handled in `lp_value_cmp` in a somewhat unexpected way.
While comparison of two none values or of a none value with (plus or minus) infinity works fine, comparison with a number type fails with an assertion (that does not even give a reason, but just `assert(0);`).
This PR handles `LP_VALUE_NONE` as yet another sentinel value that is considered the smallest of all values, even below `LP_VALUE_MINUS_INFINITY`.