### PR TITLE
Fixed memory leaks in streaming operators within C++ wrapper.

### DIFF
--- a/include/polyxx/utils.h
+++ b/include/polyxx/utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <iosfwd>
 #include <memory>
 
 namespace poly {
@@ -8,5 +9,8 @@ namespace poly {
   /** Generic type alias for a unique_ptr with a deleter function. */
   template <typename T>
   using deleting_unique_ptr = std::unique_ptr<T, std::function<void(T*)>>;
+
+  /** Writes a char pointer to an output stream and frees it afterwards. */
+  std::ostream& stream_ptr(std::ostream& os, char* ptr);
 
 }  // namespace poly

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,7 @@ set(polyxx_SOURCES
   polyxx/rational.cpp
   polyxx/sign_condition.cpp
   polyxx/upolynomial.cpp
+  polyxx/utils.cpp
   polyxx/variable.cpp
 )
 

--- a/src/polyxx/algebraic_number.cpp
+++ b/src/polyxx/algebraic_number.cpp
@@ -50,7 +50,7 @@ namespace poly {
   }
 
   std::ostream& operator<<(std::ostream& os, const AlgebraicNumber& v) {
-    return os << lp_algebraic_number_to_string(v.get_internal());
+    return stream_ptr(os, lp_algebraic_number_to_string(v.get_internal()));
   }
 
   void swap(AlgebraicNumber& lhs, AlgebraicNumber& rhs) {

--- a/src/polyxx/dyadic_interval.cpp
+++ b/src/polyxx/dyadic_interval.cpp
@@ -74,8 +74,9 @@ namespace poly {
 
   std::ostream& operator<<(std::ostream& os, const DyadicInterval& i) {
     os << (i.get_internal()->a_open ? "( " : "[ ");
-    os << lp_dyadic_rational_to_string(&(i.get_internal()->a)) << " ; "
-       << lp_dyadic_rational_to_string(&(i.get_internal()->b));
+    stream_ptr(os, lp_dyadic_rational_to_string(&(i.get_internal()->a)));
+    os << " ; ";
+    stream_ptr(os, lp_dyadic_rational_to_string(&(i.get_internal()->b)));
     os << (i.get_internal()->b_open ? " )" : " ]");
     return os;
   }

--- a/src/polyxx/dyadic_rational.cpp
+++ b/src/polyxx/dyadic_rational.cpp
@@ -53,7 +53,7 @@ namespace poly {
   }
 
   std::ostream& operator<<(std::ostream& os, const DyadicRational& r) {
-    return os << lp_dyadic_rational_to_string(r.get_internal());
+    return stream_ptr(os, lp_dyadic_rational_to_string(r.get_internal()));
   }
 
   double to_double(const DyadicRational& r) {

--- a/src/polyxx/integer.cpp
+++ b/src/polyxx/integer.cpp
@@ -70,7 +70,7 @@ namespace poly {
   const lp_integer_t* Integer::get_internal() const { return &mInt; }
 
   std::ostream& operator<<(std::ostream& os, const Integer& i) {
-    return os << lp_integer_to_string(i.get_internal());
+    return stream_ptr(os, lp_integer_to_string(i.get_internal()));
   }
 
   std::size_t bit_size(const Integer& i) {

--- a/src/polyxx/integer_ring.cpp
+++ b/src/polyxx/integer_ring.cpp
@@ -29,7 +29,7 @@ namespace poly {
   }
 
   std::ostream& operator<<(std::ostream& os, const IntegerRing& ir) {
-    return os << lp_int_ring_to_string(ir.get_internal());
+    return stream_ptr(os, lp_int_ring_to_string(ir.get_internal()));
   }
 
 }  // namespace poly

--- a/src/polyxx/rational.cpp
+++ b/src/polyxx/rational.cpp
@@ -44,7 +44,7 @@ namespace poly {
   const lp_rational_t* Rational::get_internal() const { return &mRat; }
 
   std::ostream& operator<<(std::ostream& os, const Rational& r) {
-    return os << lp_rational_to_string(r.get_internal());
+    return stream_ptr(os, lp_rational_to_string(r.get_internal()));
   }
 
   double to_double(const Rational& r) {

--- a/src/polyxx/upolynomial.cpp
+++ b/src/polyxx/upolynomial.cpp
@@ -111,7 +111,7 @@ namespace poly {
   }
 
   std::ostream& operator<<(std::ostream& os, const UPolynomial& p) {
-    return os << lp_upolynomial_to_string(p.get_internal());
+    return stream_ptr(os, lp_upolynomial_to_string(p.get_internal()));
   }
 
   bool is_zero(const UPolynomial& p) {

--- a/src/polyxx/utils.cpp
+++ b/src/polyxx/utils.cpp
@@ -1,0 +1,11 @@
+#include "polyxx/utils.h"
+
+#include <iostream>
+
+namespace poly {
+  std::ostream& stream_ptr(std::ostream& os, char* ptr) {
+    os << ptr;
+    free(ptr);
+    return os;
+  }
+}


### PR DESCRIPTION
I noticed that the previous pattern to implement `operator<<()` for the C++ wrapper classes leads to leaking memory in many cases. This PR fixes this issue.