### PR TITLE
Improve setup times on travis, make scripts consistent for ubuntu and osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,18 @@ compiler:
   - clang
   - gcc
 
+addons:
+  apt:
+    packages:
+      - cmake
+      - libgmp-dev
+      - make
+  homebrew:
+    packages:
+      - cmake
+      - gmp
+      - pyenv
+
 env:
   matrix:
     # iam: the precise versions are need, so we know whether we have to install
@@ -20,10 +32,6 @@ env:
     - CMAKE_BUILD_TYPE=Debug PYTHON=3.6.7
     - CMAKE_BUILD_TYPE=Release PYTHON=2.7.15
     - CMAKE_BUILD_TYPE=Release PYTHON=3.6.7
-
-before_install:
-   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-key update; sudo apt-get update; fi
-   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
 
 install:
    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then ./scripts/ubuntu.deps.sh; fi

--- a/scripts/osx.deps.sh
+++ b/scripts/osx.deps.sh
@@ -1,19 +1,15 @@
 #!/bin/bash
-brew outdated cmake || brew upgrade cmake
-brew outdated gmp || brew upgrade gmp
 
+echo 'eval "$(pyenv init -)"' >> ${HOME}/.bash_profile
 
-brew outdated pyenv || brew upgrade pyenv;
+source ${HOME}/.bash_profile
 
-echo $PYTHON
+pyenv versions | grep ${PYTHON}
+if [[ $? != 0 ]]; then
+    pyenv install ${PYTHON}
+fi
 
-echo 'eval "$(pyenv init -)"' >> ${HOME}/.bash_profile;
-
-source ${HOME}/.bash_profile;
-
-# no python 2.7.15 or 3.6.7 on osx as of 10/2019;
-pyenv install ${PYTHON};
-pyenv global ${PYTHON};
-
+echo "Using ${PYTHON}"
+pyenv global ${PYTHON}
 
 pip install sympy

--- a/scripts/ubuntu.deps.sh
+++ b/scripts/ubuntu.deps.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-sudo apt-get install cmake make libgmp-dev
 
-echo $PYTHON
+echo 'eval "$(pyenv init -)"' >> ${HOME}/.bash_profile
 
-echo 'eval "$(pyenv init -)"' >> ${HOME}/.bash_profile;
-source ${HOME}/.bash_profile;
+source ${HOME}/.bash_profile
 
-# iam: this should show us what our choices are.
-pyenv versions
+pyenv versions | grep ${PYTHON}
+if [[ $? != 0 ]]; then
+    pyenv install ${PYTHON}
+fi
 
-pyenv global ${PYTHON};
+echo "Using ${PYTHON}"
+pyenv global ${PYTHON}
 
 pip install sympy


### PR DESCRIPTION
I found that travis jobs took way longer on macos because brew packages were being updated.
As I have not found a particularly good reason for this, this PR removes that and performs some general cleanup on the travis setup.