### PR TITLE
Allow -fPIC build on all platforms

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,11 +122,16 @@ endif()
 # Linux, FreeBSD, and old versions of Darwin (and probably other systems) don't use fPIC by default.
 # We just check for Linux and FreeBSD here.
 # 
-if(LIBPOLY_BUILD_STATIC_PIC AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+if(LIBPOLY_BUILD_STATIC_PIC)
   add_library(static_pic_poly STATIC ${poly_SOURCES})
   set_target_properties(static_pic_poly PROPERTIES OUTPUT_NAME picpoly POSITION_INDEPENDENT_CODE true)
 
   add_library(static_pic_polyxx STATIC ${polyxx_SOURCES})
   set_target_properties(static_pic_polyxx PROPERTIES OUTPUT_NAME picpolyxx POSITION_INDEPENDENT_CODE true)
   target_link_libraries(static_pic_polyxx static_pic_poly)
+
+  if(NOT (${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD"))
+    set_target_properties(static_pic_poly PROPERTIES EXCLUDE_FROM_ALL ON)
+    set_target_properties(static_pic_polyxx PROPERTIES EXCLUDE_FROM_ALL ON)
+  endif()
 endif()


### PR DESCRIPTION
The current cmake setup contains a safeguard that prevents having explicit `-fPIC` enabled builds if the current platform is known to have `-fPIC` by default anyway.
This makes using libpoly in an automated way more difficult than necessary: assume we want to build it in a platform-agnostic way and only build the thing we need (static with `-fPIC`), we currently need to replicate this logic and compile either `static_poly` or `static_pic_poly` and then link against either `libpoly.a` or `libpicpoly.a` (or instead manually move `libpicpoly.a` to `libpoly.a`).
The only benefits of this safeguard seem to be to (a) avoid the overhead of compilation if we do not need `-fPIC` and run `make [all]` and (b) possibly make the user aware of this issue.

This PR weakens this mechanism and instead sets `EXCLUDE_FROM_ALL` on the `-fPIC` enabled targets if `-fPIC` is enabled by default anyway. This still avoids the cost for compiling the library a second time, but allows to compile the `-fPIC` version explicitly if one wants to.
On platforms that would not have these targets beforehand, this should produce the exact same library as `static_poly` does.