### PR TITLE
Fix memory leak in C++ wrapper

### DIFF
--- a/src/polyxx/dyadic_interval.cpp
+++ b/src/polyxx/dyadic_interval.cpp
@@ -45,10 +45,12 @@ namespace poly {
   }
 
   DyadicInterval& DyadicInterval::operator=(const DyadicInterval& i) {
+    lp_dyadic_interval_destruct(get_internal());
     lp_dyadic_interval_construct_copy(get_internal(), i.get_internal());
     return *this;
   }
   DyadicInterval& DyadicInterval::operator=(DyadicInterval&& i) {
+    lp_dyadic_interval_destruct(get_internal());
     lp_dyadic_interval_construct_copy(get_internal(), i.get_internal());
     return *this;
   }

--- a/src/polyxx/interval.cpp
+++ b/src/polyxx/interval.cpp
@@ -32,6 +32,7 @@ namespace poly {
   Interval::~Interval() { lp_interval_destruct(get_internal()); }
 
   Interval& Interval::operator=(const Interval& i) {
+    lp_interval_destruct(get_internal());
     lp_interval_construct_copy(get_internal(), i.get_internal());
     return *this;
   }

--- a/src/polyxx/interval_assignment.cpp
+++ b/src/polyxx/interval_assignment.cpp
@@ -15,6 +15,7 @@ namespace poly {
   }
   IntervalAssignment& IntervalAssignment::operator=(IntervalAssignment&& ia) {
     // Copy internals, reconstruct argument to be empty
+    lp_interval_assignment_destruct(get_internal());
     mAssignment = ia.mAssignment;
     lp_interval_assignment_construct(ia.get_internal(), ia.mAssignment.var_db);
     return *this;


### PR DESCRIPTION
This PR fixes a subtle memory leak in certain assignment and move assignment constructors in the C++ wrapper.
We sometimes construct a new object over the existing object without destructing the existing object beforehand.