### PR TITLE
CMakeLists.txt: de-quote conditional appending of open_memstream.c

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,7 @@ set(poly_SOURCES
 )
 
 if (NOT HAVE_OPEN_MEMSTREAM) 
-  set(poly_SOURCES "utils/open_memstream.c ${poly_SOURCES}")
+  set(poly_SOURCES utils/open_memstream.c ${poly_SOURCES})
 endif()
 
 set(polyxx_SOURCES


### PR DESCRIPTION
I'm just fixing up the Nix package for `libpoly` on darwin and am finding I need to make this change to prevent 0.1.9's build failing with

```
CMake Error at src/CMakeLists.txt:73 (add_library):
  Cannot find source file:

    utils/open_memstream.c utils/debug_trace.c
```

Full log: https://nix-cache.s3.amazonaws.com/log/r4y0c1mgrj3h0dbxscfawxf2nqww923q-libpoly-0.1.9.drv

With the quoting in place it appears to be failing to interpret `utils/open_memstream.c` and `utils/debug_trace.c` as two separate entries.

This is on macos 10.15 with cmake 3.19.7.