### PR TITLE
Add operator/() and inverse() for the C++ wrapper AlgebraicNumber()

### DIFF
--- a/include/polyxx/algebraic_number.h
+++ b/include/polyxx/algebraic_number.h
@@ -203,8 +203,13 @@ namespace poly {
   /** Multiply two algebraic numbers. */
   AlgebraicNumber operator*(const AlgebraicNumber& lhs,
                             const AlgebraicNumber& rhs);
+  /** Divide two algebraic numbers. Assumes rhs != 0. */
+  AlgebraicNumber operator/(const AlgebraicNumber& lhs,
+                            const AlgebraicNumber& rhs);
   /** Compute lhs^n. */
   AlgebraicNumber pow(const AlgebraicNumber& lhs, unsigned n);
+  /** Compute 1/an. Assumes an != 0. */
+  AlgebraicNumber inverse(const AlgebraicNumber& lhs);
 
   /** Check whether an algebraic number is a rational.
    * This check is not complete.

--- a/src/polyxx/algebraic_number.cpp
+++ b/src/polyxx/algebraic_number.cpp
@@ -281,9 +281,21 @@ namespace poly {
                             rhs.get_internal());
     return res;
   }
+  AlgebraicNumber operator/(const AlgebraicNumber& lhs,
+                            const AlgebraicNumber& rhs) {
+    AlgebraicNumber res;
+    lp_algebraic_number_div(res.get_internal(), lhs.get_internal(),
+                            rhs.get_internal());
+    return res;
+  }
   AlgebraicNumber pow(const AlgebraicNumber& lhs, unsigned n) {
     AlgebraicNumber res;
     lp_algebraic_number_pow(res.get_internal(), lhs.get_internal(), n);
+    return res;
+  }
+  AlgebraicNumber inverse(const AlgebraicNumber& an) {
+    AlgebraicNumber res;
+    lp_algebraic_number_inv(res.get_internal(), an.get_internal());
     return res;
   }
 

--- a/test/polyxx/test_algebraic_number.cpp
+++ b/test/polyxx/test_algebraic_number.cpp
@@ -75,3 +75,9 @@ TEST_CASE("algebraic_number::floor") {
   CHECK(floor(AlgebraicNumber(UPolynomial({-2, 0, 1}), DyadicInterval(1, 2))) ==
         Integer(1));
 }
+TEST_CASE("algebraic_number::operator/") {
+  AlgebraicNumber sqrt2(UPolynomial({-2, 0, 1}), DyadicInterval(1, 2));
+  CHECK(is_one(sqrt2 / sqrt2));
+  CHECK(sqrt2 / -sqrt2 == Rational(-1));
+  CHECK(-(sqrt2 / -sqrt2) == Rational(1));
+}


### PR DESCRIPTION
This PR adds `operator/()` and `inverse()` for the C++ wrapper class `AlgebraicNumber`.