### PR TITLE
Improve lp_algebraic_number_to_rational

### DIFF
--- a/src/number/algebraic_number.c
+++ b/src/number/algebraic_number.c
@@ -28,6 +28,7 @@
 #include "polynomial/coefficient.h"
 #include "polynomial/output.h"
 #include "upolynomial/output.h"
+#include "upolynomial/upolynomial.h"
 
 #include "utils/debug_trace.h"
 
@@ -545,9 +546,26 @@ void lp_algebraic_number_to_rational(const lp_algebraic_number_t* a_const, lp_ra
 
   lp_rational_t tmp;
 
-  // If a point, just return it's double
-  if (a_const->f == 0) {
+  // we have a point interval, return the point
+  if (lp_dyadic_interval_is_point(&a_const->I)) {
     rational_construct_from_dyadic(&tmp, &a_const->I.a);
+    rational_swap(q, &tmp);
+    rational_destruct(&tmp);
+    return;
+  }
+  assert(a_const->f != 0);
+  // we have a linear polynomial, just solve it
+  if (lp_upolynomial_degree(a_const->f) == 1) {
+    if (a_const->f->size == 1) {
+      // a*x + 0
+      rational_construct_from_int(&tmp, 0, 1);
+      rational_swap(q, &tmp);
+      rational_destruct(&tmp);
+    }
+    assert(a_const->f->size == 2);
+    // a*x + b
+    rational_construct_from_div(&tmp, &a_const->f->monomials[0].coefficient, &a_const->f->monomials[1].coefficient);
+    rational_neg(&tmp, &tmp);
     rational_swap(q, &tmp);
     rational_destruct(&tmp);
     return;

--- a/test/polyxx/test_algebraic_number.cpp
+++ b/test/polyxx/test_algebraic_number.cpp
@@ -63,6 +63,19 @@ TEST_CASE("algebraic_number::is_integer") {
       is_integer(AlgebraicNumber(UPolynomial({3, 1}), DyadicInterval(-4, -2))));
 }
 
+TEST_CASE("algebraic_number::to_rational") {
+  {
+    AlgebraicNumber an(UPolynomial({1, 3}), DyadicInterval(-2, 0));
+    CHECK(is_rational(an));
+    CHECK(to_rational_approximation(an) == Rational(-1, 3));
+  }
+  {
+    AlgebraicNumber an(UPolynomial({3, 1}), DyadicInterval(-4, -2));
+    CHECK(is_rational(an));
+    CHECK(to_rational_approximation(an) == Rational(-3));
+  }
+}
+
 TEST_CASE("algebraic_number::ceil") {
   CHECK(ceil(AlgebraicNumber(UPolynomial({-2, 0, 1}),
                              DyadicInterval(-2, -1))) == Integer(-1));


### PR DESCRIPTION
Sometimes `lp_algebraic_number_is_rational` would correctly identify that an algebraic number is in fact rational, but `lp_algebraic_number_to_rational` would fail to return this exact rational. This happens when the algebraic number has a defining polynomial, but the isolating interval is a point interval or the polynomial is only linear.
This PR fixes this issue by implementing these cases in `lp_algebraic_number_to_rational`.
Now, whenever `lp_algebraic_number_is_rational` returns true, `lp_algebraic_number_to_rational` should produce the exact rational value.