### PR TITLE
Make tests conditional on BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,9 @@ if(LIBPOLY_BUILD_PYTHON_API)
 
 endif()
 
-# Configure the C++ tests
-enable_testing()
-add_subdirectory(test/polyxx)
+if (BUILD_TESTING)
+  # Configure the C++ tests
+  enable_testing()
+  add_subdirectory(test/polyxx)
+endif()
 


### PR DESCRIPTION
There is no need to build all tests unconditionally.
BUILD_TESTING is the standard variable in cmake: https://cmake.org/cmake/help/latest/module/CTest.html