### PR TITLE
Use Py_hash_t as return type of hash functions

### DIFF
--- a/python/polypyPolynomial3.c
+++ b/python/polypyPolynomial3.c
@@ -54,7 +54,7 @@ Polynomial_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 static PyObject*
 Polynomial_richcompare(PyObject* self, PyObject* args, int op);
 
-static long
+static Py_hash_t
 Polynomial_hash(PyObject* self);
 
 static PyObject*
@@ -407,10 +407,10 @@ Polynomial_richcompare(PyObject* self, PyObject* other, int op) {
   return result;
 }
 
-static long
+static Py_hash_t
 Polynomial_hash(PyObject* self) {
   Polynomial* p = (Polynomial*) self;
-  long hash = lp_polynomial_hash(p->p);
+  Py_hash_t hash = lp_polynomial_hash(p->p);
   if (hash == -1) {
     // value -1 should not be returned as a normal return value
     hash = 0;

--- a/python/polypyValue3.c
+++ b/python/polypyValue3.c
@@ -42,7 +42,7 @@ Value_richcompare(PyObject* self, PyObject* other, int op);
 static PyObject*
 Value_str(PyObject* self);
 
-static long
+static Py_hash_t
 Value_hash(PyObject* self);
 
 static PyObject*
@@ -304,10 +304,10 @@ static PyObject* Value_str(PyObject* self) {
   return pystr;
 }
 
-static long
+static Py_hash_t
 Value_hash(PyObject* self) {
   Value* v = (Value*) self;
-  long hash = lp_value_hash(&v->v);
+  Py_hash_t hash = lp_value_hash(&v->v);
   if (hash == -1) {
     // value -1 should not be returned as a normal return value
     hash = 0;

--- a/python/polypyVariable3.c
+++ b/python/polypyVariable3.c
@@ -56,7 +56,7 @@ Variable_str(PyObject* self);
 static PyObject*
 Variable_repr(PyObject* self);
 
-static long
+static Py_hash_t
 Variable_hash(PyObject* self);
 
 static PyObject *
@@ -227,7 +227,7 @@ static PyObject* Variable_repr(PyObject* self) {
   return str;
 }
 
-static long Variable_hash(PyObject* self) {
+static Py_hash_t Variable_hash(PyObject* self) {
   Variable* x = (Variable*) self;
   return x->x;
 }


### PR DESCRIPTION
Fixes https://github.com/SRI-CSL/libpoly/issues/70.  The `Py_hash_t` type may or may not be the same size as long, and is definitely not the same size on i386 Linux and FreeBSD.
