### PR TITLE
Removed dynamically sized arrays

### DIFF
--- a/src/polyxx/polynomial.cpp
+++ b/src/polyxx/polynomial.cpp
@@ -377,7 +377,7 @@ namespace poly {
 
   std::vector<Polynomial> psc(const Polynomial& p, const Polynomial& q) {
     std::size_t size = std::min(degree(p), degree(q)) + 1;
-    lp_polynomial_t* tmp[size];
+    lp_polynomial_t **tmp = (lp_polynomial_t**)malloc(size * sizeof(lp_polynomial_t*));
     for (std::size_t i = 0; i < size; ++i) {
       tmp[i] = lp_polynomial_new(detail::context(p, q));
     }
@@ -386,12 +386,13 @@ namespace poly {
     for (std::size_t i = 0; i < size; ++i) {
       res.emplace_back(tmp[i]);
     }
+    free(tmp);
     return res;
   }
 
   std::vector<Polynomial> subres(const Polynomial& p, const Polynomial& q) {
     std::size_t size = std::min(degree(p), degree(q)) + 1;
-    lp_polynomial_t* tmp[size];
+    lp_polynomial_t **tmp = (lp_polynomial_t**)malloc(size * sizeof(lp_polynomial_t*));
     for (std::size_t i = 0; i < size; ++i) {
       tmp[i] = lp_polynomial_new(detail::context(p, q));
     }
@@ -400,6 +401,7 @@ namespace poly {
     for (std::size_t i = 0; i < size; ++i) {
       res.emplace_back(tmp[i]);
     }
+    free(tmp);
     return res;
   }
 

--- a/src/polyxx/upolynomial.cpp
+++ b/src/polyxx/upolynomial.cpp
@@ -100,16 +100,18 @@ namespace poly {
   }
 
   std::vector<Integer> coefficients(const UPolynomial& p) {
-    lp_integer_t coeffs[degree(p) + 1];
-    for (std::size_t i = 0; i < degree(p) + 1; ++i) {
+    std::size_t size = degree(p) + 1;
+    lp_integer_t *coeffs = (lp_integer_t*)malloc(size * sizeof(lp_integer_t));
+    for (std::size_t i = 0; i < size; ++i) {
       lp_integer_construct_from_int(lp_Z, &coeffs[i], 0);
     }
     lp_upolynomial_unpack(p.get_internal(), coeffs);
     std::vector<Integer> res;
-    for (std::size_t i = 0; i < degree(p) + 1; ++i) {
+    for (std::size_t i = 0; i < size; ++i) {
       res.emplace_back(&coeffs[i]);
       lp_integer_destruct(&coeffs[i]);
     }
+    free(coeffs);
     return res;
   }
 


### PR DESCRIPTION
Removes variable length arrays in C++ wrapper code.
Fixes issue #86 